### PR TITLE
Finalize Codex assistant panel workflow in desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,13 @@ Audience split:
 
 The real Mohio desktop app starts in `desktop/`.
 
-Typical local workflow:
+Quikstart development:
 
-1. `cd desktop`
-2. `npm install`
-3. `npm run dev`
+```
+cd desktop
+npm install
+npm run dev
+```
 
 Other useful commands:
 

--- a/desktop/src/main/assistant.test.ts
+++ b/desktop/src/main/assistant.test.ts
@@ -3,6 +3,7 @@
 import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
+import type { AssistantEvent, AssistantThread } from "@shared/mohio-types";
 import { createAssistantRuntime } from "./assistant";
 
 class FakeAssistantProcess extends EventEmitter {
@@ -13,28 +14,191 @@ class FakeAssistantProcess extends EventEmitter {
     this.emit("close", null, signal ?? "SIGTERM");
     return true;
   });
+
+  private bufferedInput = "";
+  private queuedRequests: Array<{ id: number; method: string; params?: unknown }> = [];
+  private requestResolvers: Array<(request: { id: number; method: string; params?: unknown }) => void> = [];
+
+  constructor() {
+    super();
+
+    this.stdin.on("data", (chunk) => {
+      this.bufferedInput += chunk.toString();
+      const requestLines = this.bufferedInput.split("\n");
+      this.bufferedInput = requestLines.pop() ?? "";
+
+      for (const requestLine of requestLines) {
+        if (!requestLine.trim()) {
+          continue;
+        }
+
+        const request = JSON.parse(requestLine) as { id: number; method: string; params?: unknown };
+        const pendingResolver = this.requestResolvers.shift();
+
+        if (pendingResolver) {
+          pendingResolver(request);
+        } else {
+          this.queuedRequests.push(request);
+        }
+      }
+    });
+  }
+
+  async nextRequest() {
+    const queuedRequest = this.queuedRequests.shift();
+
+    if (queuedRequest) {
+      return queuedRequest;
+    }
+
+    return new Promise<{ id: number; method: string; params?: unknown }>((resolve) => {
+      this.requestResolvers.push(resolve);
+    });
+  }
+
+  drainRequests() {
+    const queuedRequests = [...this.queuedRequests];
+    this.queuedRequests = [];
+    return queuedRequests;
+  }
+
+  notify(method: string, params: unknown) {
+    this.stdout.write(`${JSON.stringify({ method, params })}\n`);
+  }
+
+  respondError(id: number, message: string) {
+    this.stdout.write(`${JSON.stringify({ error: { message }, id })}\n`);
+  }
+
+  respondSuccess(id: number, result: unknown) {
+    this.stdout.write(`${JSON.stringify({ id, result })}\n`);
+  }
 }
 
 describe("assistant runtime", () => {
-  it("runs Codex from the active workspace root and streams assistant deltas", () => {
+  it("lists workspace-filtered Codex threads and strips Mohio prompt wrappers", async () => {
     const process = new FakeAssistantProcess();
-    const spawnProcess = vi.fn().mockReturnValue(process);
+    const runtime = createAssistantRuntime({
+      spawnProcess: vi.fn().mockReturnValue(process),
+    });
+
+    const listPromise = runtime.listThreads({
+      workspacePath: "/workspaces/alpha",
+    });
+
+    const initializeRequest = await process.nextRequest();
+    process.respondSuccess(initializeRequest.id, {
+      userAgent: "codex-test",
+    });
+
+    const listRequest = await process.nextRequest();
+    expect(listRequest.method).toBe("thread/list");
+    expect(listRequest.params).toMatchObject({
+      archived: false,
+      cwd: "/workspaces/alpha",
+      sortKey: "updated_at",
+    });
+    process.respondSuccess(listRequest.id, {
+      data: [
+        {
+          cliVersion: "0.0.0",
+          createdAt: 1711152000,
+          cwd: "/workspaces/alpha",
+          ephemeral: false,
+          id: "thread-2",
+          modelProvider: "openai",
+          name: null,
+          path: "/Users/test/.codex/sessions/thread-2",
+          preview: "[MOHIO_USER_REQUEST]\nSummarize this note\n[/MOHIO_USER_REQUEST]\n\nCurrent note body",
+          source: "vscode",
+          status: { type: "idle" },
+          turns: [],
+          updatedAt: 1711155600,
+          agentNickname: null,
+          agentRole: null,
+          gitInfo: null,
+        },
+      ],
+      nextCursor: null,
+    });
+
+    await expect(listPromise).resolves.toEqual([
+      {
+        createdAt: "2024-03-23T00:00:00.000Z",
+        id: "thread-2",
+        preview: "Summarize this note",
+        status: "idle",
+        title: "Summarize this note",
+        updatedAt: "2024-03-23T01:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("creates a Codex thread, sends a note-aware message, and streams assistant text", async () => {
+    const process = new FakeAssistantProcess();
     const runtime = createAssistantRuntime({
       createId: vi.fn()
         .mockReturnValueOnce("user-1")
         .mockReturnValueOnce("assistant-1"),
-      now: () => "2026-03-22T00:00:00.000Z",
-      spawnProcess,
+      now: () => "2026-03-23T00:00:00.000Z",
+      spawnProcess: vi.fn().mockReturnValue(process),
     });
-    const threadEvents: string[] = [];
+    let lastThreadEvent: AssistantThread | null = null;
 
-    runtime.onThreadChanged((event) => {
-      if (event.thread.messages.length > 0) {
-        threadEvents.push(event.thread.messages[event.thread.messages.length - 1]?.content ?? "");
+    runtime.onEvent((event: AssistantEvent) => {
+      if (event.type === "thread") {
+        lastThreadEvent = event.thread;
       }
     });
 
-    const thread = runtime.sendMessage({
+    const createThreadPromise = runtime.createThread({
+      workspacePath: "/workspaces/alpha",
+    });
+
+    process.respondSuccess((await process.nextRequest()).id, {
+      userAgent: "codex-test",
+    });
+
+    const createThreadRequest = await process.nextRequest();
+    expect(createThreadRequest.method).toBe("thread/start");
+    expect(createThreadRequest.params).toMatchObject({
+      approvalPolicy: "never",
+      cwd: "/workspaces/alpha",
+      persistExtendedHistory: true,
+      sandbox: "read-only",
+    });
+    process.respondSuccess(createThreadRequest.id, {
+      approvalPolicy: "never",
+      cwd: "/workspaces/alpha",
+      model: "gpt-5.4",
+      modelProvider: "openai",
+      reasoningEffort: null,
+      sandbox: { type: "readOnly", access: {} },
+      thread: {
+        cliVersion: "0.0.0",
+        createdAt: 1774224000,
+        cwd: "/workspaces/alpha",
+        ephemeral: false,
+        id: "thread-1",
+        modelProvider: "openai",
+        name: null,
+        path: "/Users/test/.codex/sessions/thread-1",
+        preview: "",
+        source: "app-server",
+        status: { type: "idle" },
+        turns: [],
+        updatedAt: 1774224000,
+        agentNickname: null,
+        agentRole: null,
+        gitInfo: null,
+      },
+    });
+
+    const createdThread = await createThreadPromise;
+    expect(createdThread.id).toBe("thread-1");
+
+    const sendPromise = runtime.sendMessage({
+      threadId: "thread-1",
       workspacePath: "/workspaces/alpha",
       workspaceName: "alpha",
       noteRelativePath: "docs/Plan.md",
@@ -43,201 +207,639 @@ describe("assistant runtime", () => {
       documentMarkdown: "Body.\n",
     });
 
-    expect(spawnProcess).toHaveBeenCalledWith(
-      "codex",
-      expect.arrayContaining([
-        "--ask-for-approval",
-        "never",
-        "exec",
-        "--json",
-        "--ephemeral",
-        "--skip-git-repo-check",
-        "--sandbox",
-        "read-only",
-        "-C",
-        "/workspaces/alpha",
-      ]),
-      expect.objectContaining({
-        cwd: "/workspaces/alpha",
-      }),
-    );
-    expect(spawnProcess.mock.calls[0]?.[1]).not.toContain("docs/Plan.md");
-    expect(thread.status).toBe("running");
-    expect(thread.messages).toEqual([
-      {
-        id: "user-1",
-        role: "user",
-        content: "Summarize this note",
-        createdAt: "2026-03-22T00:00:00.000Z",
-      },
-      {
-        id: "assistant-1",
-        role: "assistant",
-        content: "",
-        createdAt: "2026-03-22T00:00:00.000Z",
-      },
-    ]);
+    const turnStartRequest = await nextNonThreadListRequest(process, "Summarize this note");
 
-    process.stderr.write("WARN noisy stderr line\n");
-    process.stdout.write('{"type":"thread.started","thread_id":"123"}\n');
-    process.stdout.write('{"type":"agent_message_delta","delta":"First "}\n');
-    process.stdout.write('{"type":"agent_message_delta","delta":"answer."}\n');
-    process.stdout.write('{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"First answer."}}\n');
-    process.emit("close", 0, null);
+    expect(turnStartRequest.method).toBe("turn/start");
+    expect(turnStartRequest.params).toMatchObject({
+      cwd: "/workspaces/alpha",
+      threadId: "thread-1",
+    });
+    expect(JSON.stringify(turnStartRequest.params)).toContain("docs/Plan.md");
+    expect(JSON.stringify(turnStartRequest.params)).toContain("Summarize this note");
+    process.respondSuccess(turnStartRequest.id, {
+      turn: {
+        error: null,
+        id: "turn-1",
+        items: [],
+        status: "inProgress",
+      },
+    });
 
-    expect(runtime.getThread({
-      workspacePath: "/workspaces/alpha",
-      noteRelativePath: "docs/Plan.md",
-    })).toEqual({
-      noteRelativePath: "docs/Plan.md",
+    await expect(sendPromise).resolves.toMatchObject({
+      id: "thread-1",
       messages: [
         {
-          id: "user-1",
-          role: "user",
           content: "Summarize this note",
-          createdAt: "2026-03-22T00:00:00.000Z",
-        },
-        {
-          id: "assistant-1",
-          role: "assistant",
-          content: "First answer.",
-          createdAt: "2026-03-22T00:00:00.000Z",
-        },
-      ],
-      status: "idle",
-      errorMessage: null,
-    });
-    expect(threadEvents).toContain("First answer.");
-  });
-
-  it("surfaces assistant failures as a thread-local error", () => {
-    const process = new FakeAssistantProcess();
-    const runtime = createAssistantRuntime({
-      createId: vi.fn()
-        .mockReturnValueOnce("user-1")
-        .mockReturnValueOnce("assistant-1"),
-      now: () => "2026-03-22T00:00:00.000Z",
-      spawnProcess: vi.fn().mockReturnValue(process),
-    });
-
-    runtime.sendMessage({
-      workspacePath: "/workspaces/alpha",
-      workspaceName: "alpha",
-      noteRelativePath: "README.md",
-      content: "Help",
-      documentTitle: "README",
-      documentMarkdown: "Body.\n",
-    });
-
-    process.stdout.write('{"type":"error","message":"Network unavailable"}\n');
-    process.emit("close", 1, null);
-
-    expect(runtime.getThread({
-      workspacePath: "/workspaces/alpha",
-      noteRelativePath: "README.md",
-    })).toEqual({
-      noteRelativePath: "README.md",
-      messages: [
-        {
           id: "user-1",
           role: "user",
-          content: "Help",
-          createdAt: "2026-03-22T00:00:00.000Z",
         },
         {
+          content: "",
           id: "assistant-1",
           role: "assistant",
-          content: "",
-          createdAt: "2026-03-22T00:00:00.000Z",
         },
       ],
-      status: "error",
-      errorMessage: "Network unavailable",
-    });
-  });
-
-  it("cancels the active run and resets the thread state", () => {
-    const process = new FakeAssistantProcess();
-    const runtime = createAssistantRuntime({
-      createId: vi.fn()
-        .mockReturnValueOnce("user-1")
-        .mockReturnValueOnce("assistant-1"),
-      now: () => "2026-03-22T00:00:00.000Z",
-      spawnProcess: vi.fn().mockReturnValue(process),
+      status: "running",
     });
 
-    runtime.sendMessage({
-      workspacePath: "/workspaces/alpha",
-      workspaceName: "alpha",
-      noteRelativePath: "README.md",
-      content: "Help",
-      documentTitle: "README",
-      documentMarkdown: "Body.\n",
+    process.notify("item/agentMessage/delta", {
+      delta: "First ",
+      itemId: "assistant-item-1",
+      threadId: "thread-1",
+      turnId: "turn-1",
     });
-
-    runtime.cancelRun({
-      workspacePath: "/workspaces/alpha",
-      noteRelativePath: "README.md",
+    process.notify("item/completed", {
+      item: {
+        id: "assistant-item-1",
+        phase: null,
+        text: "First answer.",
+        type: "agentMessage",
+      },
+      threadId: "thread-1",
+      turnId: "turn-1",
     });
-
-    expect(process.kill).toHaveBeenCalledWith("SIGTERM");
-    expect(runtime.getThread({
-      workspacePath: "/workspaces/alpha",
-      noteRelativePath: "README.md",
-    })).toMatchObject({
-      noteRelativePath: "README.md",
-      status: "idle",
-      errorMessage: null,
+    process.notify("turn/completed", {
+      threadId: "thread-1",
+      turn: {
+        error: null,
+        id: "turn-1",
+        items: [],
+        status: "completed",
+      },
     });
-  });
+    await flushEvents();
 
-  it("migrates note conversation state after a rename", () => {
-    const process = new FakeAssistantProcess();
-    const runtime = createAssistantRuntime({
-      createId: vi.fn()
-        .mockReturnValueOnce("user-1")
-        .mockReturnValueOnce("assistant-1"),
-      now: () => "2026-03-22T00:00:00.000Z",
-      spawnProcess: vi.fn().mockReturnValue(process),
-    });
-
-    runtime.sendMessage({
-      workspacePath: "/workspaces/alpha",
-      workspaceName: "alpha",
-      noteRelativePath: "Draft.md",
-      content: "Help",
-      documentTitle: "Draft",
-      documentMarkdown: "Body.\n",
-    });
-    process.emit("close", 0, null);
-
-    runtime.migrateThread({
-      workspacePath: "/workspaces/alpha",
-      fromRelativePath: "Draft.md",
-      toRelativePath: "Final.md",
-    });
-
-    expect(runtime.getThread({
-      workspacePath: "/workspaces/alpha",
-      noteRelativePath: "Final.md",
-    })).toMatchObject({
-      noteRelativePath: "Final.md",
+    expect(lastThreadEvent).toMatchObject({
+      id: "thread-1",
       messages: [
         expect.objectContaining({
+          content: "Summarize this note",
           role: "user",
-          content: "Help",
         }),
         expect.objectContaining({
+          content: "First answer.",
           role: "assistant",
         }),
       ],
-    });
-    expect(runtime.getThread({
-      workspacePath: "/workspaces/alpha",
-      noteRelativePath: "Draft.md",
-    })).toMatchObject({
-      noteRelativePath: "Draft.md",
-      messages: [],
+      status: "idle",
     });
   });
+
+  it("keeps streamed assistant text when the completed item arrives empty", async () => {
+    const process = new FakeAssistantProcess();
+    const runtime = createAssistantRuntime({
+      createId: vi.fn()
+        .mockReturnValueOnce("user-1")
+        .mockReturnValueOnce("assistant-1"),
+      now: () => "2026-03-23T00:00:00.000Z",
+      spawnProcess: vi.fn().mockReturnValue(process),
+    });
+    let lastThreadEvent: AssistantThread | null = null;
+
+    runtime.onEvent((event: AssistantEvent) => {
+      if (event.type === "thread") {
+        lastThreadEvent = event.thread;
+      }
+    });
+
+    const createThreadPromise = runtime.createThread({
+      workspacePath: "/workspaces/alpha",
+    });
+
+    process.respondSuccess((await process.nextRequest()).id, {
+      userAgent: "codex-test",
+    });
+
+    const createThreadRequest = await process.nextRequest();
+    process.respondSuccess(createThreadRequest.id, {
+      approvalPolicy: "never",
+      cwd: "/workspaces/alpha",
+      model: "gpt-5.4",
+      modelProvider: "openai",
+      reasoningEffort: null,
+      sandbox: { type: "readOnly", access: {} },
+      thread: {
+        cliVersion: "0.0.0",
+        createdAt: 1774224000,
+        cwd: "/workspaces/alpha",
+        ephemeral: false,
+        id: "thread-keep-stream",
+        modelProvider: "openai",
+        name: null,
+        path: "/Users/test/.codex/sessions/thread-keep-stream",
+        preview: "",
+        source: "app-server",
+        status: { type: "idle" },
+        turns: [],
+        updatedAt: 1774224000,
+        agentNickname: null,
+        agentRole: null,
+        gitInfo: null,
+      },
+    });
+
+    await expect(createThreadPromise).resolves.toMatchObject({
+      id: "thread-keep-stream",
+    });
+
+    const sendPromise = runtime.sendMessage({
+      threadId: "thread-keep-stream",
+      workspacePath: "/workspaces/alpha",
+      workspaceName: "alpha",
+      noteRelativePath: "docs/Plan.md",
+      content: "Summarize this note",
+      documentTitle: "Plan",
+      documentMarkdown: "Body.\n",
+    });
+
+    const turnStartRequest = await nextNonThreadListRequest(process, "Summarize this note");
+    process.respondSuccess(turnStartRequest.id, {
+      turn: {
+        error: null,
+        id: "turn-keep-stream",
+        items: [],
+        status: "inProgress",
+      },
+    });
+
+    await expect(sendPromise).resolves.toMatchObject({
+      id: "thread-keep-stream",
+      status: "running",
+    });
+
+    process.notify("item/agentMessage/delta", {
+      delta: "Streamed text that should stay.",
+      itemId: "assistant-item-keep-stream",
+      threadId: "thread-keep-stream",
+      turnId: "turn-keep-stream",
+    });
+    process.notify("item/completed", {
+      item: {
+        id: "assistant-item-keep-stream",
+        phase: null,
+        text: "",
+        type: "agentMessage",
+      },
+      threadId: "thread-keep-stream",
+      turnId: "turn-keep-stream",
+    });
+    process.notify("turn/completed", {
+      threadId: "thread-keep-stream",
+      turn: {
+        error: null,
+        id: "turn-keep-stream",
+        items: [],
+        status: "completed",
+      },
+    });
+    await flushEvents();
+
+    expect(lastThreadEvent).toMatchObject({
+      id: "thread-keep-stream",
+      messages: [
+        expect.objectContaining({
+          content: "Summarize this note",
+          role: "user",
+        }),
+        expect.objectContaining({
+          content: "Streamed text that should stay.",
+          role: "assistant",
+        }),
+      ],
+      status: "idle",
+    });
+  });
+
+  it("falls back to thread/read without turns for a brand new unmaterialized thread", async () => {
+    const process = new FakeAssistantProcess();
+    const runtime = createAssistantRuntime({
+      spawnProcess: vi.fn().mockReturnValue(process),
+    });
+
+    const getThreadPromise = runtime.getThread({
+      threadId: "thread-empty",
+      workspacePath: "/workspaces/alpha",
+    });
+
+    process.respondSuccess((await process.nextRequest()).id, {
+      userAgent: "codex-test",
+    });
+
+    const firstReadRequest = await process.nextRequest();
+    expect(firstReadRequest.method).toBe("thread/read");
+    expect(firstReadRequest.params).toEqual({
+      includeTurns: true,
+      threadId: "thread-empty",
+    });
+    process.respondError(
+      firstReadRequest.id,
+      "thread thread-empty is not materialized yet; includeTurns is unavailable before first user message",
+    );
+
+    const fallbackReadRequest = await process.nextRequest();
+    expect(fallbackReadRequest.method).toBe("thread/read");
+    expect(fallbackReadRequest.params).toEqual({
+      includeTurns: false,
+      threadId: "thread-empty",
+    });
+    process.respondSuccess(fallbackReadRequest.id, {
+      thread: {
+        cliVersion: "0.0.0",
+        createdAt: 1774224000,
+        cwd: "/workspaces/alpha",
+        ephemeral: false,
+        id: "thread-empty",
+        modelProvider: "openai",
+        name: null,
+        path: "/Users/test/.codex/sessions/thread-empty",
+        preview: "",
+        source: "app-server",
+        status: { type: "idle" },
+        turns: [],
+        updatedAt: 1774224000,
+        agentNickname: null,
+        agentRole: null,
+        gitInfo: null,
+      },
+    });
+
+    await expect(getThreadPromise).resolves.toMatchObject({
+      id: "thread-empty",
+      messages: [],
+      status: "idle",
+    });
+  });
+
+  it("resumes an existing Codex thread before starting a new turn", async () => {
+    const process = new FakeAssistantProcess();
+    const runtime = createAssistantRuntime({
+      createId: vi.fn()
+        .mockReturnValueOnce("user-1")
+        .mockReturnValueOnce("assistant-1"),
+      now: () => "2026-03-23T00:00:00.000Z",
+      spawnProcess: vi.fn().mockReturnValue(process),
+    });
+
+    const getThreadPromise = runtime.getThread({
+      threadId: "thread-existing",
+      workspacePath: "/workspaces/alpha",
+    });
+
+    process.respondSuccess((await process.nextRequest()).id, {
+      userAgent: "codex-test",
+    });
+
+    const readRequest = await process.nextRequest();
+    expect(readRequest.method).toBe("thread/read");
+    process.respondSuccess(readRequest.id, {
+      thread: {
+        cliVersion: "0.0.0",
+        createdAt: 1774224000,
+        cwd: "/workspaces/alpha",
+        ephemeral: false,
+        id: "thread-existing",
+        modelProvider: "openai",
+        name: "Existing chat",
+        path: "/Users/test/.codex/sessions/thread-existing",
+        preview: "Existing chat",
+        source: "app-server",
+        status: { type: "idle" },
+        turns: [],
+        updatedAt: 1774224000,
+        agentNickname: null,
+        agentRole: null,
+        gitInfo: null,
+      },
+    });
+
+    await expect(getThreadPromise).resolves.toMatchObject({
+      id: "thread-existing",
+      title: "Existing chat",
+    });
+
+    const sendPromise = runtime.sendMessage({
+      threadId: "thread-existing",
+      workspacePath: "/workspaces/alpha",
+      workspaceName: "alpha",
+      noteRelativePath: "docs/Plan.md",
+      content: "Continue this chat",
+      documentTitle: "Plan",
+      documentMarkdown: "Body.\n",
+    });
+
+    const resumeRequest = await process.nextRequest();
+    expect(resumeRequest.method).toBe("thread/resume");
+    expect(resumeRequest.params).toMatchObject({
+      cwd: "/workspaces/alpha",
+      threadId: "thread-existing",
+    });
+    process.respondSuccess(resumeRequest.id, {
+      thread: {
+        cliVersion: "0.0.0",
+        createdAt: 1774224000,
+        cwd: "/workspaces/alpha",
+        ephemeral: false,
+        id: "thread-existing",
+        modelProvider: "openai",
+        name: "Existing chat",
+        path: "/Users/test/.codex/sessions/thread-existing",
+        preview: "Existing chat",
+        source: "app-server",
+        status: { type: "idle" },
+        turns: [],
+        updatedAt: 1774224000,
+        agentNickname: null,
+        agentRole: null,
+        gitInfo: null,
+      },
+    });
+
+    const turnStartRequest = await nextNonThreadListRequest(process, "Existing chat");
+    expect(turnStartRequest.method).toBe("turn/start");
+    expect(turnStartRequest.params).toMatchObject({
+      cwd: "/workspaces/alpha",
+      threadId: "thread-existing",
+    });
+    process.respondSuccess(turnStartRequest.id, {
+      turn: {
+        error: null,
+        id: "turn-2",
+        items: [],
+        status: "inProgress",
+      },
+    });
+
+    await expect(sendPromise).resolves.toMatchObject({
+      id: "thread-existing",
+      status: "running",
+    });
+  });
+
+  it("retries a brand new thread after a no-rollout turn/start error", async () => {
+    const process = new FakeAssistantProcess();
+    const runtime = createAssistantRuntime({
+      createId: vi.fn()
+        .mockReturnValueOnce("user-1")
+        .mockReturnValueOnce("assistant-1"),
+      now: () => "2026-03-23T00:00:00.000Z",
+      spawnProcess: vi.fn().mockReturnValue(process),
+    });
+
+    const createThreadPromise = runtime.createThread({
+      workspacePath: "/workspaces/alpha",
+    });
+
+    process.respondSuccess((await process.nextRequest()).id, {
+      userAgent: "codex-test",
+    });
+
+    const createThreadRequest = await process.nextRequest();
+    expect(createThreadRequest.method).toBe("thread/start");
+    process.respondSuccess(createThreadRequest.id, {
+      thread: {
+        cliVersion: "0.0.0",
+        createdAt: 1774224000,
+        cwd: "/workspaces/alpha",
+        ephemeral: false,
+        id: "thread-fresh",
+        modelProvider: "openai",
+        name: null,
+        path: "/Users/test/.codex/sessions/thread-fresh",
+        preview: "",
+        source: "app-server",
+        status: { type: "idle" },
+        turns: [],
+        updatedAt: 1774224000,
+        agentNickname: null,
+        agentRole: null,
+        gitInfo: null,
+      },
+    });
+
+    await expect(createThreadPromise).resolves.toMatchObject({
+      id: "thread-fresh",
+    });
+
+    const sendPromise = runtime.sendMessage({
+      threadId: "thread-fresh",
+      workspacePath: "/workspaces/alpha",
+      workspaceName: "alpha",
+      noteRelativePath: "docs/Plan.md",
+      content: "Summarize this note",
+      documentTitle: "Plan",
+      documentMarkdown: "Body.\n",
+    });
+
+    const firstTurnStartRequest = await nextNonThreadListRequest(process, "Summarize this note");
+    expect(firstTurnStartRequest.method).toBe("turn/start");
+    process.respondError(firstTurnStartRequest.id, "no rollout found for thread id thread-fresh");
+
+    const resumeRequest = await process.nextRequest();
+    expect(resumeRequest.method).toBe("thread/resume");
+    expect(resumeRequest.params).toMatchObject({
+      cwd: "/workspaces/alpha",
+      threadId: "thread-fresh",
+    });
+    process.respondSuccess(resumeRequest.id, {
+      thread: {
+        cliVersion: "0.0.0",
+        createdAt: 1774224000,
+        cwd: "/workspaces/alpha",
+        ephemeral: false,
+        id: "thread-fresh",
+        modelProvider: "openai",
+        name: null,
+        path: "/Users/test/.codex/sessions/thread-fresh",
+        preview: "Summarize this note",
+        source: "app-server",
+        status: { type: "idle" },
+        turns: [],
+        updatedAt: 1774224000,
+        agentNickname: null,
+        agentRole: null,
+        gitInfo: null,
+      },
+    });
+
+    const retriedTurnStartRequest = await nextNonThreadListRequest(process, "Summarize this note");
+    expect(retriedTurnStartRequest.method).toBe("turn/start");
+    process.respondSuccess(retriedTurnStartRequest.id, {
+      turn: {
+        error: null,
+        id: "turn-fresh",
+        items: [],
+        status: "inProgress",
+      },
+    });
+
+    await expect(sendPromise).resolves.toMatchObject({
+      id: "thread-fresh",
+      status: "running",
+    });
+  });
+
+  it("keeps retrying no-rollout turn/start errors for a new thread before succeeding", async () => {
+    const process = new FakeAssistantProcess();
+    const runtime = createAssistantRuntime({
+      createId: vi.fn()
+        .mockReturnValueOnce("user-1")
+        .mockReturnValueOnce("assistant-1"),
+      now: () => "2026-03-23T00:00:00.000Z",
+      spawnProcess: vi.fn().mockReturnValue(process),
+    });
+
+    const createThreadPromise = runtime.createThread({
+      workspacePath: "/workspaces/alpha",
+    });
+
+    process.respondSuccess((await process.nextRequest()).id, {
+      userAgent: "codex-test",
+    });
+
+    const createThreadRequest = await process.nextRequest();
+    process.respondSuccess(createThreadRequest.id, {
+      thread: {
+        cliVersion: "0.0.0",
+        createdAt: 1774224000,
+        cwd: "/workspaces/alpha",
+        ephemeral: false,
+        id: "thread-retry-many",
+        modelProvider: "openai",
+        name: null,
+        path: "/Users/test/.codex/sessions/thread-retry-many",
+        preview: "",
+        source: "app-server",
+        status: { type: "idle" },
+        turns: [],
+        updatedAt: 1774224000,
+        agentNickname: null,
+        agentRole: null,
+        gitInfo: null,
+      },
+    });
+
+    await expect(createThreadPromise).resolves.toMatchObject({
+      id: "thread-retry-many",
+    });
+
+    const sendPromise = runtime.sendMessage({
+      threadId: "thread-retry-many",
+      workspacePath: "/workspaces/alpha",
+      workspaceName: "alpha",
+      noteRelativePath: "docs/Plan.md",
+      content: "Summarize this note",
+      documentTitle: "Plan",
+      documentMarkdown: "Body.\n",
+    });
+
+    const firstTurnStartRequest = await nextNonThreadListRequest(process, "Summarize this note");
+    expect(firstTurnStartRequest.method).toBe("turn/start");
+    process.respondError(firstTurnStartRequest.id, "no rollout found for thread id thread-retry-many");
+
+    const firstResumeRequest = await process.nextRequest();
+    expect(firstResumeRequest.method).toBe("thread/resume");
+    process.respondSuccess(firstResumeRequest.id, {
+      thread: {
+        cliVersion: "0.0.0",
+        createdAt: 1774224000,
+        cwd: "/workspaces/alpha",
+        ephemeral: false,
+        id: "thread-retry-many",
+        modelProvider: "openai",
+        name: null,
+        path: "/Users/test/.codex/sessions/thread-retry-many",
+        preview: "Summarize this note",
+        source: "app-server",
+        status: { type: "idle" },
+        turns: [],
+        updatedAt: 1774224000,
+        agentNickname: null,
+        agentRole: null,
+        gitInfo: null,
+      },
+    });
+
+    const secondTurnStartRequest = await nextNonThreadListRequest(process, "Summarize this note");
+    expect(secondTurnStartRequest.method).toBe("turn/start");
+    process.respondError(secondTurnStartRequest.id, "no rollout found for thread id thread-retry-many");
+
+    const secondResumeRequest = await process.nextRequest();
+    expect(secondResumeRequest.method).toBe("thread/resume");
+    process.respondSuccess(secondResumeRequest.id, {
+      thread: {
+        cliVersion: "0.0.0",
+        createdAt: 1774224000,
+        cwd: "/workspaces/alpha",
+        ephemeral: false,
+        id: "thread-retry-many",
+        modelProvider: "openai",
+        name: null,
+        path: "/Users/test/.codex/sessions/thread-retry-many",
+        preview: "Summarize this note",
+        source: "app-server",
+        status: { type: "idle" },
+        turns: [],
+        updatedAt: 1774224000,
+        agentNickname: null,
+        agentRole: null,
+        gitInfo: null,
+      },
+    });
+
+    const thirdTurnStartRequest = await nextNonThreadListRequest(process, "Summarize this note");
+    expect(thirdTurnStartRequest.method).toBe("turn/start");
+    process.respondSuccess(thirdTurnStartRequest.id, {
+      turn: {
+        error: null,
+        id: "turn-retry-many",
+        items: [],
+        status: "inProgress",
+      },
+    });
+
+    await expect(sendPromise).resolves.toMatchObject({
+      id: "thread-retry-many",
+      status: "running",
+    });
+  });
+
 });
+
+async function flushEvents() {
+  await new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
+
+async function nextNonThreadListRequest(process: FakeAssistantProcess, preview: string) {
+  let request = await process.nextRequest();
+
+  while (request.method === "thread/list") {
+    process.respondSuccess(request.id, {
+      data: [
+        {
+          cliVersion: "0.0.0",
+          createdAt: 1774224000,
+          cwd: "/workspaces/alpha",
+          ephemeral: false,
+          id: "thread-1",
+          modelProvider: "openai",
+          name: null,
+          path: "/Users/test/.codex/sessions/thread-1",
+          preview,
+          source: "app-server",
+          status: { type: "active", activeFlags: [] },
+          turns: [],
+          updatedAt: 1774224000,
+          agentNickname: null,
+          agentRole: null,
+          gitInfo: null,
+        },
+      ],
+      nextCursor: null,
+    });
+    request = await process.nextRequest();
+  }
+
+  return request;
+}

--- a/desktop/src/main/assistant.test.ts
+++ b/desktop/src/main/assistant.test.ts
@@ -1,0 +1,243 @@
+// @vitest-environment node
+
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import { createAssistantRuntime } from "./assistant";
+
+class FakeAssistantProcess extends EventEmitter {
+  stdin = new PassThrough();
+  stdout = new PassThrough();
+  stderr = new PassThrough();
+  kill = vi.fn((signal?: NodeJS.Signals) => {
+    this.emit("close", null, signal ?? "SIGTERM");
+    return true;
+  });
+}
+
+describe("assistant runtime", () => {
+  it("runs Codex from the active workspace root and streams assistant deltas", () => {
+    const process = new FakeAssistantProcess();
+    const spawnProcess = vi.fn().mockReturnValue(process);
+    const runtime = createAssistantRuntime({
+      createId: vi.fn()
+        .mockReturnValueOnce("user-1")
+        .mockReturnValueOnce("assistant-1"),
+      now: () => "2026-03-22T00:00:00.000Z",
+      spawnProcess,
+    });
+    const threadEvents: string[] = [];
+
+    runtime.onThreadChanged((event) => {
+      if (event.thread.messages.length > 0) {
+        threadEvents.push(event.thread.messages[event.thread.messages.length - 1]?.content ?? "");
+      }
+    });
+
+    const thread = runtime.sendMessage({
+      workspacePath: "/workspaces/alpha",
+      workspaceName: "alpha",
+      noteRelativePath: "docs/Plan.md",
+      content: "Summarize this note",
+      documentTitle: "Plan",
+      documentMarkdown: "Body.\n",
+    });
+
+    expect(spawnProcess).toHaveBeenCalledWith(
+      "codex",
+      expect.arrayContaining([
+        "--ask-for-approval",
+        "never",
+        "exec",
+        "--json",
+        "--ephemeral",
+        "--skip-git-repo-check",
+        "--sandbox",
+        "read-only",
+        "-C",
+        "/workspaces/alpha",
+      ]),
+      expect.objectContaining({
+        cwd: "/workspaces/alpha",
+      }),
+    );
+    expect(spawnProcess.mock.calls[0]?.[1]).not.toContain("docs/Plan.md");
+    expect(thread.status).toBe("running");
+    expect(thread.messages).toEqual([
+      {
+        id: "user-1",
+        role: "user",
+        content: "Summarize this note",
+        createdAt: "2026-03-22T00:00:00.000Z",
+      },
+      {
+        id: "assistant-1",
+        role: "assistant",
+        content: "",
+        createdAt: "2026-03-22T00:00:00.000Z",
+      },
+    ]);
+
+    process.stderr.write("WARN noisy stderr line\n");
+    process.stdout.write('{"type":"thread.started","thread_id":"123"}\n');
+    process.stdout.write('{"type":"agent_message_delta","delta":"First "}\n');
+    process.stdout.write('{"type":"agent_message_delta","delta":"answer."}\n');
+    process.stdout.write('{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"First answer."}}\n');
+    process.emit("close", 0, null);
+
+    expect(runtime.getThread({
+      workspacePath: "/workspaces/alpha",
+      noteRelativePath: "docs/Plan.md",
+    })).toEqual({
+      noteRelativePath: "docs/Plan.md",
+      messages: [
+        {
+          id: "user-1",
+          role: "user",
+          content: "Summarize this note",
+          createdAt: "2026-03-22T00:00:00.000Z",
+        },
+        {
+          id: "assistant-1",
+          role: "assistant",
+          content: "First answer.",
+          createdAt: "2026-03-22T00:00:00.000Z",
+        },
+      ],
+      status: "idle",
+      errorMessage: null,
+    });
+    expect(threadEvents).toContain("First answer.");
+  });
+
+  it("surfaces assistant failures as a thread-local error", () => {
+    const process = new FakeAssistantProcess();
+    const runtime = createAssistantRuntime({
+      createId: vi.fn()
+        .mockReturnValueOnce("user-1")
+        .mockReturnValueOnce("assistant-1"),
+      now: () => "2026-03-22T00:00:00.000Z",
+      spawnProcess: vi.fn().mockReturnValue(process),
+    });
+
+    runtime.sendMessage({
+      workspacePath: "/workspaces/alpha",
+      workspaceName: "alpha",
+      noteRelativePath: "README.md",
+      content: "Help",
+      documentTitle: "README",
+      documentMarkdown: "Body.\n",
+    });
+
+    process.stdout.write('{"type":"error","message":"Network unavailable"}\n');
+    process.emit("close", 1, null);
+
+    expect(runtime.getThread({
+      workspacePath: "/workspaces/alpha",
+      noteRelativePath: "README.md",
+    })).toEqual({
+      noteRelativePath: "README.md",
+      messages: [
+        {
+          id: "user-1",
+          role: "user",
+          content: "Help",
+          createdAt: "2026-03-22T00:00:00.000Z",
+        },
+        {
+          id: "assistant-1",
+          role: "assistant",
+          content: "",
+          createdAt: "2026-03-22T00:00:00.000Z",
+        },
+      ],
+      status: "error",
+      errorMessage: "Network unavailable",
+    });
+  });
+
+  it("cancels the active run and resets the thread state", () => {
+    const process = new FakeAssistantProcess();
+    const runtime = createAssistantRuntime({
+      createId: vi.fn()
+        .mockReturnValueOnce("user-1")
+        .mockReturnValueOnce("assistant-1"),
+      now: () => "2026-03-22T00:00:00.000Z",
+      spawnProcess: vi.fn().mockReturnValue(process),
+    });
+
+    runtime.sendMessage({
+      workspacePath: "/workspaces/alpha",
+      workspaceName: "alpha",
+      noteRelativePath: "README.md",
+      content: "Help",
+      documentTitle: "README",
+      documentMarkdown: "Body.\n",
+    });
+
+    runtime.cancelRun({
+      workspacePath: "/workspaces/alpha",
+      noteRelativePath: "README.md",
+    });
+
+    expect(process.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(runtime.getThread({
+      workspacePath: "/workspaces/alpha",
+      noteRelativePath: "README.md",
+    })).toMatchObject({
+      noteRelativePath: "README.md",
+      status: "idle",
+      errorMessage: null,
+    });
+  });
+
+  it("migrates note conversation state after a rename", () => {
+    const process = new FakeAssistantProcess();
+    const runtime = createAssistantRuntime({
+      createId: vi.fn()
+        .mockReturnValueOnce("user-1")
+        .mockReturnValueOnce("assistant-1"),
+      now: () => "2026-03-22T00:00:00.000Z",
+      spawnProcess: vi.fn().mockReturnValue(process),
+    });
+
+    runtime.sendMessage({
+      workspacePath: "/workspaces/alpha",
+      workspaceName: "alpha",
+      noteRelativePath: "Draft.md",
+      content: "Help",
+      documentTitle: "Draft",
+      documentMarkdown: "Body.\n",
+    });
+    process.emit("close", 0, null);
+
+    runtime.migrateThread({
+      workspacePath: "/workspaces/alpha",
+      fromRelativePath: "Draft.md",
+      toRelativePath: "Final.md",
+    });
+
+    expect(runtime.getThread({
+      workspacePath: "/workspaces/alpha",
+      noteRelativePath: "Final.md",
+    })).toMatchObject({
+      noteRelativePath: "Final.md",
+      messages: [
+        expect.objectContaining({
+          role: "user",
+          content: "Help",
+        }),
+        expect.objectContaining({
+          role: "assistant",
+        }),
+      ],
+    });
+    expect(runtime.getThread({
+      workspacePath: "/workspaces/alpha",
+      noteRelativePath: "Draft.md",
+    })).toMatchObject({
+      noteRelativePath: "Draft.md",
+      messages: [],
+    });
+  });
+});

--- a/desktop/src/main/assistant.ts
+++ b/desktop/src/main/assistant.ts
@@ -3,18 +3,23 @@ import { createInterface } from "node:readline";
 import type {
   AssistantEvent,
   AssistantMessage,
+  AssistantRunStatus,
   AssistantThread,
+  AssistantThreadSummary,
   SendAssistantMessageInput,
 } from "@shared/mohio-types";
 
 const DEFAULT_ASSISTANT_INSTRUCTIONS = [
   "You are Codex embedded inside Mohio, a local-first Markdown workspace for small teams.",
-  "Work as a chat-only workspace assistant.",
-  "The active note is the primary context, but you may inspect the rest of the workspace when useful.",
-  "Do not propose patches, diffs, or direct file edits in this environment.",
-  "Do not claim to have changed files.",
-  "Respond in concise, practical product language.",
+  "Work as a chat-first assistant for a Markdown knowledgebase.",
+  "Treat the active note as the primary context and the wider workspace as supporting context.",
+  "You may inspect the rest of the workspace when useful.",
+  "Do not make file edits, propose patches, or claim to have changed files in this environment.",
+  "Return concise, practical answers that fit a document-first workflow.",
 ].join("\n");
+
+const MOHIO_PROMPT_OPEN = "[MOHIO_USER_REQUEST]";
+const MOHIO_PROMPT_CLOSE = "[/MOHIO_USER_REQUEST]";
 
 type AssistantProcess = Pick<
   ChildProcessWithoutNullStreams,
@@ -27,16 +32,34 @@ type SpawnAssistantProcess = (
   options: SpawnOptionsWithoutStdio,
 ) => AssistantProcess;
 
+interface JsonRpcRequest {
+  id: number;
+  method: string;
+  params?: unknown;
+}
+
+interface JsonRpcResponse {
+  id?: number;
+  result?: unknown;
+  error?: {
+    code?: number;
+    message?: string;
+  };
+  method?: string;
+  params?: unknown;
+}
+
+interface AssistantThreadState {
+  assistantMessageId: string | null;
+  isTurnReady: boolean;
+  thread: AssistantThread;
+  turnId: string | null;
+}
+
 interface AssistantRuntimeOptions {
   createId?: () => string;
   now?: () => string;
   spawnProcess?: SpawnAssistantProcess;
-}
-
-interface AssistantRunState {
-  child: AssistantProcess | null;
-  lastErrorMessages: string[];
-  thread: AssistantThread;
 }
 
 interface SendAssistantRunInput extends SendAssistantMessageInput {
@@ -44,16 +67,22 @@ interface SendAssistantRunInput extends SendAssistantMessageInput {
   workspacePath: string;
 }
 
+interface AssistantServerConnection {
+  request: <T>(method: string, params?: unknown) => Promise<T>;
+}
+
+const TURN_START_MAX_ROLLOUT_RETRIES = 3;
+const TURN_START_ROLLOUT_RETRY_DELAY_MS = 120;
+
 export interface AssistantRuntime {
-  cancelRun: (input: { noteRelativePath: string; workspacePath: string }) => void;
-  getThread: (input: { noteRelativePath: string; workspacePath: string }) => AssistantThread;
-  migrateThread: (input: {
-    fromRelativePath: string;
-    toRelativePath: string;
-    workspacePath: string;
-  }) => void;
-  onThreadChanged: (listener: (event: AssistantEvent) => void) => () => void;
-  sendMessage: (input: SendAssistantRunInput) => AssistantThread;
+  cancelRun: (input: { threadId: string; workspacePath: string }) => Promise<void>;
+  createThread: (input: { workspacePath: string }) => Promise<AssistantThread>;
+  deleteThread: (input: { threadId: string; workspacePath: string }) => Promise<void>;
+  getThread: (input: { threadId: string; workspacePath: string }) => Promise<AssistantThread>;
+  listThreads: (input: { workspacePath: string }) => Promise<AssistantThreadSummary[]>;
+  onEvent: (listener: (event: AssistantEvent) => void) => () => void;
+  renameThread: (input: { threadId: string; title: string; workspacePath: string }) => Promise<void>;
+  sendMessage: (input: SendAssistantRunInput) => Promise<AssistantThread>;
 }
 
 export function createAssistantRuntime({
@@ -62,114 +91,247 @@ export function createAssistantRuntime({
   spawnProcess = spawn,
 }: AssistantRuntimeOptions = {}): AssistantRuntime {
   const listeners = new Set<(event: AssistantEvent) => void>();
-  const threadStates = new Map<string, AssistantRunState>();
+  const threadStates = new Map<string, AssistantThreadState>();
+  let connectionPromise: Promise<AssistantServerConnection> | null = null;
 
-  const emitThreadChanged = (workspacePath: string, noteRelativePath: string) => {
-    const thread = cloneThread(getOrCreateThreadState({ noteRelativePath, workspacePath }).thread);
-    const event: AssistantEvent = {
-      workspacePath,
-      noteRelativePath,
-      thread,
-    };
-
+  const emit = (event: AssistantEvent) => {
     for (const listener of listeners) {
       listener(event);
     }
   };
 
-  const finalizeRun = ({
-    child,
-    code,
-    noteRelativePath,
-    signal,
-    workspacePath,
-  }: {
-    child: AssistantProcess;
-    code: number | null;
-    noteRelativePath: string;
-    signal: NodeJS.Signals | null;
-    workspacePath: string;
-  }) => {
-    const state = getOrCreateThreadState({ noteRelativePath, workspacePath });
+  const emitThread = (threadId: string) => {
+    const threadState = threadStates.get(threadId);
 
-    if (state.child !== child) {
+    if (!threadState) {
       return;
     }
 
-    state.child = null;
+    emit({
+      type: "thread",
+      workspacePath: threadState.thread.workspacePath,
+      thread: cloneThread(threadState.thread),
+    });
+  };
 
-    if (code === 0) {
-      state.thread.status = "idle";
-      state.thread.errorMessage = null;
-    } else {
-      state.thread.status = "error";
-      state.thread.errorMessage = getRunErrorMessage({
-        noteRelativePath,
-        signal,
-        state,
+  const emitThreadList = async (workspacePath: string) => {
+    try {
+      const threads = await listThreads({ workspacePath });
+      emit({
+        type: "thread-list",
+        workspacePath,
+        threads,
+      });
+    } catch {
+      // Keep list refresh failures local to explicit API calls.
+    }
+  };
+
+  const getConnection = () => {
+    if (!connectionPromise) {
+      connectionPromise = createServerConnection({
+        onExit: (errorMessage) => {
+          for (const [threadId, threadState] of threadStates.entries()) {
+            if (threadState.thread.status !== "running") {
+              continue;
+            }
+
+            threadState.turnId = null;
+            threadState.assistantMessageId = null;
+            threadState.thread.status = "error";
+            threadState.thread.errorMessage = errorMessage;
+            emitThread(threadId);
+          }
+
+          connectionPromise = null;
+        },
+        onNotification: (notification) => {
+          handleServerNotification({
+            createId,
+            emitThread,
+            emitThreadList,
+            now,
+            notification,
+            threadStates,
+          });
+        },
+        spawnProcess,
       });
     }
 
-    emitThreadChanged(workspacePath, noteRelativePath);
+    return connectionPromise;
   };
 
-  const handleAssistantEvent = ({
-    event,
-    noteRelativePath,
+  const cacheThread = (
+    thread: AssistantThread,
+    options: {
+      isTurnReady?: boolean;
+    } = {},
+  ) => {
+    const existingState = threadStates.get(thread.id);
+    threadStates.set(thread.id, {
+      assistantMessageId: existingState?.assistantMessageId ?? null,
+      isTurnReady: options.isTurnReady ?? existingState?.isTurnReady ?? false,
+      thread,
+      turnId: existingState?.turnId ?? null,
+    });
+  };
+
+  const ensureLoadedThread = async ({
+    threadId,
     workspacePath,
   }: {
-    event: unknown;
-    noteRelativePath: string;
+    threadId: string;
     workspacePath: string;
   }) => {
-    const state = getOrCreateThreadState({ noteRelativePath, workspacePath });
-    const parsedEvent = isRecord(event) ? event : null;
+    const connection = await getConnection();
+    const threadState = threadStates.get(threadId);
 
-    if (!parsedEvent) {
-      return;
+    if (threadState?.thread.workspacePath === workspacePath && threadState.isTurnReady) {
+      return threadState.thread;
     }
 
-    if (parsedEvent.type === "error" && typeof parsedEvent.message === "string") {
-      state.lastErrorMessages.push(parsedEvent.message);
-      return;
-    }
+    const response = await connection.request<{ thread: CodexThread }>("thread/resume", {
+      approvalPolicy: "never",
+      cwd: workspacePath,
+      developerInstructions: DEFAULT_ASSISTANT_INSTRUCTIONS,
+      persistExtendedHistory: true,
+      sandbox: "read-only",
+      threadId,
+    });
+    const assistantThread = mapCodexThreadToAssistantThread({
+      thread: response.thread,
+      workspacePath,
+    });
 
-    const delta = extractAssistantText(parsedEvent);
+    cacheThread(assistantThread, {
+      isTurnReady: true,
+    });
 
-    if (!delta) {
-      return;
-    }
-
-    const assistantMessage = state.thread.messages[state.thread.messages.length - 1];
-
-    if (!assistantMessage || assistantMessage.role !== "assistant") {
-      return;
-    }
-
-    assistantMessage.content = delta.mode === "append"
-      ? `${assistantMessage.content}${delta.text}`
-      : delta.text;
-
-    emitThreadChanged(workspacePath, noteRelativePath);
+    return assistantThread;
   };
 
-  const sendMessage = ({
+  const listThreads = async ({
+    workspacePath,
+  }: {
+    workspacePath: string;
+  }): Promise<AssistantThreadSummary[]> => {
+    const connection = await getConnection();
+    let nextCursor: string | null = null;
+    const threads: AssistantThreadSummary[] = [];
+
+    do {
+      const response: { data: CodexThread[]; nextCursor: string | null } = await connection.request("thread/list", {
+        archived: false,
+        cursor: nextCursor,
+        cwd: workspacePath,
+        sortKey: "updated_at",
+      });
+
+      for (const thread of response.data) {
+        threads.push(mapCodexThreadToSummary(thread));
+      }
+
+      nextCursor = response.nextCursor;
+    } while (nextCursor);
+
+    return threads.sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+  };
+
+  const createThread = async ({
+    workspacePath,
+  }: {
+    workspacePath: string;
+  }): Promise<AssistantThread> => {
+    const connection = await getConnection();
+    const response = await connection.request<{ thread: CodexThread }>("thread/start", {
+      approvalPolicy: "never",
+      cwd: workspacePath,
+      developerInstructions: DEFAULT_ASSISTANT_INSTRUCTIONS,
+      ephemeral: false,
+      experimentalRawEvents: false,
+      persistExtendedHistory: true,
+      sandbox: "read-only",
+    });
+    const assistantThread = mapCodexThreadToAssistantThread({
+      thread: response.thread,
+      workspacePath,
+    });
+
+    cacheThread(assistantThread, {
+      isTurnReady: true,
+    });
+    void emitThreadList(workspacePath);
+    emitThread(assistantThread.id);
+
+    return cloneThread(assistantThread);
+  };
+
+  const getThread = async ({
+    threadId,
+    workspacePath,
+  }: {
+    threadId: string;
+    workspacePath: string;
+  }): Promise<AssistantThread> => {
+    const connection = await getConnection();
+    let response: { thread: CodexThread };
+
+    try {
+      response = await connection.request<{ thread: CodexThread }>("thread/read", {
+        includeTurns: true,
+        threadId,
+      });
+    } catch (error) {
+      if (!isUnmaterializedThreadReadError(error)) {
+        throw error;
+      }
+
+      response = await connection.request<{ thread: CodexThread }>("thread/read", {
+        includeTurns: false,
+        threadId,
+      });
+    }
+
+    const assistantThread = mapCodexThreadToAssistantThread({
+      thread: response.thread,
+      workspacePath,
+    });
+
+    cacheThread(assistantThread, {
+      isTurnReady: false,
+    });
+
+    return cloneThread(assistantThread);
+  };
+
+  const sendMessage = async ({
     content,
     documentMarkdown,
     documentTitle,
     noteRelativePath,
+    threadId,
     workspaceName,
     workspacePath,
-  }: SendAssistantRunInput): AssistantThread => {
+  }: SendAssistantRunInput): Promise<AssistantThread> => {
     const trimmedContent = content.trim();
 
     if (!trimmedContent) {
       throw new Error("Enter a message before asking Codex for help.");
     }
 
-    const state = getOrCreateThreadState({ noteRelativePath, workspacePath });
+    await ensureLoadedThread({
+      threadId,
+      workspacePath,
+    });
 
-    if (state.child) {
+    const threadState = threadStates.get(threadId);
+
+    if (!threadState) {
+      throw new Error("Mohio could not load the selected Codex conversation.");
+    }
+
+    if (threadState.turnId) {
       throw new Error("Wait for the current Codex run to finish.");
     }
 
@@ -185,396 +347,805 @@ export function createAssistantRuntime({
       content: "",
       createdAt: now(),
     };
-    const prompt = buildAssistantPrompt({
-      documentMarkdown,
-      documentTitle,
-      noteRelativePath,
-      userMessage,
-      workspaceName,
-      workspacePath,
-      historyMessages: [...state.thread.messages, userMessage],
-    });
 
-    state.lastErrorMessages = [];
-    state.thread.messages = [...state.thread.messages, userMessage, assistantMessage];
-    state.thread.status = "running";
-    state.thread.errorMessage = null;
-
-    let child: AssistantProcess;
+    threadState.assistantMessageId = assistantMessage.id;
+    threadState.thread.errorMessage = null;
+    threadState.thread.messages = [...threadState.thread.messages, userMessage, assistantMessage];
+    threadState.thread.preview = threadState.thread.preview || trimmedContent;
+    threadState.thread.status = "running";
+    emitThread(threadId);
+    void emitThreadList(workspacePath);
 
     try {
-      child = spawnProcess("codex", getCodexExecArgs(workspacePath), {
+      const connection = await getConnection();
+      const turnStartParams = {
         cwd: workspacePath,
-        env: process.env,
-        stdio: "pipe",
-      });
-    } catch {
-      state.thread.status = "error";
-      state.thread.errorMessage = "Mohio could not start the installed Codex CLI.";
-      emitThreadChanged(workspacePath, noteRelativePath);
-      return cloneThread(state.thread);
-    }
+        input: [
+          {
+            text: buildAssistantPrompt({
+              documentMarkdown,
+              documentTitle,
+              noteRelativePath,
+              userRequest: trimmedContent,
+              workspaceName,
+              workspacePath,
+            }),
+            text_elements: [],
+            type: "text" as const,
+          },
+        ],
+        threadId,
+      };
+      let response: { turn: { id: string } } | null = null;
+      let rolloutRetryCount = 0;
 
-    state.child = child;
-    emitThreadChanged(workspacePath, noteRelativePath);
+      while (!response) {
+        try {
+          response = await connection.request<{ turn: { id: string } }>("turn/start", turnStartParams);
+        } catch (error) {
+          if (
+            !isNoRolloutFoundError(error) ||
+            rolloutRetryCount >= TURN_START_MAX_ROLLOUT_RETRIES
+          ) {
+            throw error;
+          }
 
-    const stdoutReader = createInterface({ input: child.stdout });
-
-    stdoutReader.on("line", (line) => {
-      const parsedLine = parseJsonLine(line);
-
-      if (!parsedLine) {
-        return;
+          rolloutRetryCount += 1;
+          await resumeThread({
+            connection,
+            threadId,
+            threadState,
+            workspacePath,
+          });
+          await wait(TURN_START_ROLLOUT_RETRY_DELAY_MS);
+        }
       }
 
-      handleAssistantEvent({
-        event: parsedLine,
-        noteRelativePath,
-        workspacePath,
-      });
-    });
+      threadState.turnId = response.turn.id;
+    } catch (error) {
+      threadState.assistantMessageId = null;
+      threadState.thread.errorMessage = getErrorMessage(error);
+      threadState.thread.status = "error";
+      emitThread(threadId);
+      throw error;
+    }
 
-    const stderrReader = createInterface({ input: child.stderr });
-    stderrReader.on("line", (line) => {
-      if (line.trim().length > 0) {
-        state.lastErrorMessages.push(line.trim());
-      }
-    });
-
-    child.on("close", (code, signal) => {
-      stdoutReader.close();
-      stderrReader.close();
-      finalizeRun({
-        child,
-        code,
-        noteRelativePath,
-        signal,
-        workspacePath,
-      });
-    });
-
-    child.stdin.write(prompt);
-    child.stdin.end();
-
-    return cloneThread(state.thread);
+    return cloneThread(threadState.thread);
   };
 
-  const cancelRun = ({
-    noteRelativePath,
-    workspacePath,
+  const cancelRun = async ({
+    threadId,
   }: {
-    noteRelativePath: string;
+    threadId: string;
     workspacePath: string;
   }) => {
-    const state = getOrCreateThreadState({ noteRelativePath, workspacePath });
+    const threadState = threadStates.get(threadId);
 
-    if (!state.child) {
+    if (!threadState?.turnId) {
       return;
     }
 
-    const activeChild = state.child;
-    state.child = null;
-    state.lastErrorMessages = [];
-    state.thread.status = "idle";
-    state.thread.errorMessage = null;
-    emitThreadChanged(workspacePath, noteRelativePath);
+    const connection = await getConnection();
+    const turnId = threadState.turnId;
 
-    try {
-      activeChild.kill("SIGTERM");
-    } catch {
-      // Ignore best-effort shutdown failures.
-    }
+    threadState.turnId = null;
+    threadState.assistantMessageId = null;
+    threadState.thread.errorMessage = null;
+    threadState.thread.status = "idle";
+    emitThread(threadId);
+    void emitThreadList(threadState.thread.workspacePath);
+
+    await connection.request<Record<string, never>>("turn/interrupt", {
+      threadId,
+      turnId,
+    });
   };
 
-  const migrateThread = ({
-    fromRelativePath,
-    toRelativePath,
+  const renameThread = async ({
+    threadId,
+    title,
     workspacePath,
   }: {
-    fromRelativePath: string;
-    toRelativePath: string;
+    threadId: string;
+    title: string;
     workspacePath: string;
   }) => {
-    if (fromRelativePath === toRelativePath) {
-      return;
+    const nextTitle = title.trim();
+
+    if (!nextTitle) {
+      throw new Error("Enter a title before renaming this chat.");
     }
 
-    const previousKey = getThreadKey(workspacePath, fromRelativePath);
-    const nextKey = getThreadKey(workspacePath, toRelativePath);
-    const previousState = threadStates.get(previousKey);
+    const connection = await getConnection();
+    await connection.request<Record<string, never>>("thread/name/set", {
+      name: nextTitle,
+      threadId,
+    });
 
-    if (!previousState) {
-      return;
+    const threadState = threadStates.get(threadId);
+
+    if (threadState) {
+      threadState.thread.title = nextTitle;
+      emitThread(threadId);
     }
 
-    previousState.thread.noteRelativePath = toRelativePath;
-    threadStates.set(nextKey, previousState);
-    threadStates.delete(previousKey);
-    emitThreadChanged(workspacePath, toRelativePath);
+    void emitThreadList(workspacePath);
   };
 
-  const getThread = ({
-    noteRelativePath,
+  const deleteThread = async ({
+    threadId,
     workspacePath,
   }: {
-    noteRelativePath: string;
+    threadId: string;
     workspacePath: string;
-  }) => cloneThread(getOrCreateThreadState({ noteRelativePath, workspacePath }).thread);
+  }) => {
+    const connection = await getConnection();
+    await connection.request<Record<string, never>>("thread/archive", {
+      threadId,
+    });
 
-  const onThreadChanged = (listener: (event: AssistantEvent) => void) => {
-    listeners.add(listener);
-
-    return () => {
-      listeners.delete(listener);
-    };
-  };
-
-  const getOrCreateThreadState = ({
-    noteRelativePath,
-    workspacePath,
-  }: {
-    noteRelativePath: string;
-    workspacePath: string;
-  }): AssistantRunState => {
-    const key = getThreadKey(workspacePath, noteRelativePath);
-    const existingState = threadStates.get(key);
-
-    if (existingState) {
-      return existingState;
-    }
-
-    const nextState: AssistantRunState = {
-      child: null,
-      lastErrorMessages: [],
-      thread: {
-        noteRelativePath,
-        messages: [],
-        status: "idle",
-        errorMessage: null,
-      },
-    };
-
-    threadStates.set(key, nextState);
-    return nextState;
+    threadStates.delete(threadId);
+    void emitThreadList(workspacePath);
   };
 
   return {
     cancelRun,
+    createThread,
+    deleteThread,
     getThread,
-    migrateThread,
-    onThreadChanged,
+    listThreads,
+    onEvent: (listener) => {
+      listeners.add(listener);
+
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    renameThread,
     sendMessage,
   };
+}
+
+function createServerConnection({
+  onExit,
+  onNotification,
+  spawnProcess,
+}: {
+  onExit: (errorMessage: string) => void;
+  onNotification: (notification: JsonRpcResponse) => void;
+  spawnProcess: SpawnAssistantProcess;
+}): Promise<AssistantServerConnection> {
+  const child = spawnProcess("codex", ["app-server"], {
+    cwd: process.cwd(),
+    env: process.env,
+    stdio: "pipe",
+  });
+  const stdoutReader = createInterface({ input: child.stdout });
+  const stderrReader = createInterface({ input: child.stderr });
+  let nextRequestId = 1;
+  const pendingRequests = new Map<number, {
+    reject: (reason?: unknown) => void;
+    resolve: (value: unknown) => void;
+  }>();
+
+  const connection = {
+    request: <T>(method: string, params?: unknown) =>
+      new Promise<T>((resolve, reject) => {
+        const requestId = nextRequestId;
+        nextRequestId += 1;
+        pendingRequests.set(requestId, {
+          reject,
+          resolve: (value) => {
+            resolve(value as T);
+          },
+        });
+
+        const request: JsonRpcRequest = {
+          id: requestId,
+          method,
+          params,
+        };
+
+        child.stdin.write(`${JSON.stringify(request)}\n`);
+      }),
+  } satisfies AssistantServerConnection;
+
+  child.on("close", () => {
+    stdoutReader.close();
+    stderrReader.close();
+
+    for (const pendingRequest of pendingRequests.values()) {
+      pendingRequest.reject(new Error("Mohio lost its connection to Codex."));
+    }
+
+    pendingRequests.clear();
+    onExit("Mohio lost its connection to the installed Codex app server.");
+  });
+
+  stdoutReader.on("line", (line) => {
+    const parsedLine = parseJsonLine(line);
+
+    if (!parsedLine) {
+      return;
+    }
+
+    if (typeof parsedLine.id === "number") {
+      const pendingRequest = pendingRequests.get(parsedLine.id);
+
+      if (!pendingRequest) {
+        return;
+      }
+
+      pendingRequests.delete(parsedLine.id);
+
+      if (parsedLine.error) {
+        pendingRequest.reject(new Error(parsedLine.error.message ?? "Codex returned an unknown error."));
+        return;
+      }
+
+      pendingRequest.resolve(parsedLine.result);
+      return;
+    }
+
+    if (typeof parsedLine.method === "string") {
+      onNotification(parsedLine);
+    }
+  });
+
+  stderrReader.on("line", () => {
+    // app-server may emit diagnostics on stderr. The structured stream remains authoritative.
+  });
+
+  return connection.request<{ userAgent: string }>("initialize", {
+    capabilities: {
+      experimentalApi: true,
+      optOutNotificationMethods: null,
+    },
+    clientInfo: {
+      name: "mohio",
+      title: "Mohio",
+      version: "0.1.0",
+    },
+  }).then(() => connection);
+}
+
+function handleServerNotification({
+  createId,
+  emitThread,
+  emitThreadList,
+  now,
+  notification,
+  threadStates,
+}: {
+  createId: () => string;
+  emitThread: (threadId: string) => void;
+  emitThreadList: (workspacePath: string) => Promise<void>;
+  now: () => string;
+  notification: JsonRpcResponse;
+  threadStates: Map<string, AssistantThreadState>;
+}) {
+  const params = isRecord(notification.params) ? notification.params : null;
+
+  if (!params || typeof notification.method !== "string") {
+    return;
+  }
+
+  if (notification.method === "thread/started") {
+    const thread = parseCodexThread(params.thread);
+
+    if (!thread) {
+      return;
+    }
+
+    const existingState = threadStates.get(thread.id);
+    threadStates.set(thread.id, {
+      assistantMessageId: existingState?.assistantMessageId ?? null,
+      isTurnReady: true,
+      thread: mapCodexThreadToAssistantThread({
+        thread,
+        workspacePath: thread.cwd,
+      }),
+      turnId: existingState?.turnId ?? null,
+    });
+    emitThread(thread.id);
+    void emitThreadList(thread.cwd);
+    return;
+  }
+
+  if (notification.method === "thread/status/changed") {
+    const threadId = typeof params.threadId === "string" ? params.threadId : null;
+    const threadState = threadId ? threadStates.get(threadId) : null;
+
+    if (!threadState || !threadId) {
+      return;
+    }
+
+    threadState.thread.status = mapCodexStatusToAssistantStatus(params.status);
+    emitThread(threadId);
+    void emitThreadList(threadState.thread.workspacePath);
+    return;
+  }
+
+  if (notification.method === "thread/name/updated") {
+    const threadId = typeof params.threadId === "string" ? params.threadId : null;
+    const threadState = threadId ? threadStates.get(threadId) : null;
+
+    if (!threadState || !threadId) {
+      return;
+    }
+
+    threadState.thread.title = typeof params.threadName === "string" && params.threadName.trim()
+      ? params.threadName
+      : threadState.thread.preview || "New chat";
+    emitThread(threadId);
+    void emitThreadList(threadState.thread.workspacePath);
+    return;
+  }
+
+  if (notification.method === "thread/archived") {
+    const threadId = typeof params.threadId === "string" ? params.threadId : null;
+    const threadState = threadId ? threadStates.get(threadId) : null;
+
+    if (!threadState || !threadId) {
+      return;
+    }
+
+    threadStates.delete(threadId);
+    void emitThreadList(threadState.thread.workspacePath);
+    return;
+  }
+
+  if (notification.method === "turn/started") {
+    const threadId = typeof params.threadId === "string" ? params.threadId : null;
+    const turn = isRecord(params.turn) ? params.turn : null;
+    const turnId = turn && typeof turn.id === "string" ? turn.id : null;
+    const threadState = threadId ? threadStates.get(threadId) : null;
+
+    if (!threadState || !threadId || !turnId) {
+      return;
+    }
+
+    threadState.turnId = turnId;
+    threadState.thread.status = "running";
+    emitThread(threadId);
+    return;
+  }
+
+  if (notification.method === "turn/completed") {
+    const threadId = typeof params.threadId === "string" ? params.threadId : null;
+    const turn = isRecord(params.turn) ? params.turn : null;
+    const threadState = threadId ? threadStates.get(threadId) : null;
+
+    if (!threadState || !threadId || !turn) {
+      return;
+    }
+
+    threadState.turnId = null;
+    threadState.assistantMessageId = null;
+
+    if (turn.status === "failed") {
+      threadState.thread.errorMessage = getTurnErrorMessage(turn.error);
+      threadState.thread.status = "error";
+    } else {
+      threadState.thread.errorMessage = null;
+      threadState.thread.status = "idle";
+    }
+
+    emitThread(threadId);
+    void emitThreadList(threadState.thread.workspacePath);
+    return;
+  }
+
+  if (notification.method === "error") {
+    const threadId = typeof params.threadId === "string" ? params.threadId : null;
+    const threadState = threadId ? threadStates.get(threadId) : null;
+    const error = isRecord(params.error) ? params.error : null;
+
+    if (!threadState || !threadId) {
+      return;
+    }
+
+    threadState.thread.errorMessage = typeof error?.message === "string"
+      ? error.message
+      : "Codex could not complete that run.";
+
+    if (params.willRetry !== true) {
+      threadState.turnId = null;
+      threadState.assistantMessageId = null;
+      threadState.thread.status = "error";
+      emitThread(threadId);
+      void emitThreadList(threadState.thread.workspacePath);
+    }
+
+    return;
+  }
+
+  if (notification.method === "item/agentMessage/delta") {
+    const threadId = typeof params.threadId === "string" ? params.threadId : null;
+    const delta = typeof params.delta === "string" ? params.delta : null;
+    const itemId = typeof params.itemId === "string" ? params.itemId : null;
+    const threadState = threadId ? threadStates.get(threadId) : null;
+
+    if (!threadState || !threadId || !delta) {
+      return;
+    }
+
+    const assistantMessage = getOrCreateAssistantMessage({
+      createId,
+      itemId,
+      now,
+      threadState,
+    });
+
+    assistantMessage.content += delta;
+    threadState.thread.status = "running";
+    emitThread(threadId);
+    return;
+  }
+
+  if (notification.method === "item/completed") {
+    const threadId = typeof params.threadId === "string" ? params.threadId : null;
+    const threadState = threadId ? threadStates.get(threadId) : null;
+    const item = isRecord(params.item) ? params.item : null;
+
+    if (!threadState || !threadId || !isAgentMessageItem(item)) {
+      return;
+    }
+
+    const assistantMessage = getOrCreateAssistantMessage({
+      createId,
+      itemId: typeof item.id === "string" ? item.id : null,
+      now,
+      threadState,
+    });
+
+    if (item.text.trim().length > 0 || assistantMessage.content.length === 0) {
+      assistantMessage.content = item.text;
+    }
+
+    emitThread(threadId);
+  }
+}
+
+function getOrCreateAssistantMessage({
+  createId,
+  itemId,
+  now,
+  threadState,
+}: {
+  createId: () => string;
+  itemId: string | null;
+  now: () => string;
+  threadState: AssistantThreadState;
+}) {
+  const pendingAssistantMessageId = threadState.assistantMessageId;
+  let assistantMessageId = pendingAssistantMessageId;
+
+  if (itemId) {
+    assistantMessageId = itemId;
+    threadState.assistantMessageId = itemId;
+  }
+
+  let assistantMessage = assistantMessageId
+    ? threadState.thread.messages.find((message) => message.id === assistantMessageId)
+    : null;
+
+  if (!assistantMessage && pendingAssistantMessageId) {
+    assistantMessage = threadState.thread.messages.find((message) => message.id === pendingAssistantMessageId) ?? null;
+
+    if (assistantMessage && itemId) {
+      assistantMessage.id = itemId;
+    }
+  }
+
+  if (!assistantMessage) {
+    assistantMessage = {
+      id: assistantMessageId ?? createId(),
+      role: "assistant",
+      content: "",
+      createdAt: now(),
+    };
+    threadState.assistantMessageId = assistantMessage.id;
+    threadState.thread.messages = [...threadState.thread.messages, assistantMessage];
+  }
+
+  return assistantMessage;
 }
 
 function buildAssistantPrompt({
   documentMarkdown,
   documentTitle,
-  historyMessages,
   noteRelativePath,
-  userMessage,
+  userRequest,
   workspaceName,
   workspacePath,
 }: {
   documentMarkdown: string;
   documentTitle: string;
-  historyMessages: AssistantMessage[];
   noteRelativePath: string;
-  userMessage: AssistantMessage;
+  userRequest: string;
   workspaceName: string;
   workspacePath: string;
 }) {
-  const renderedHistory = historyMessages.length === 0
-    ? "No previous conversation in this note thread."
-    : historyMessages
-      .map((message) => `${message.role.toUpperCase()}:\n${message.content}`)
-      .join("\n\n");
-
   return [
-    DEFAULT_ASSISTANT_INSTRUCTIONS,
+    MOHIO_PROMPT_OPEN,
+    userRequest,
+    MOHIO_PROMPT_CLOSE,
     "",
-    "Workspace context:",
-    `- Name: ${workspaceName}`,
-    `- Path: ${workspacePath}`,
-    `- Active note path: ${noteRelativePath}`,
-    `- Active note title: ${documentTitle.trim() || "Untitled"}`,
-    "",
-    "Active note Markdown:",
-    "```md",
-    documentMarkdown,
+    "Treat the current note as primary context.",
+    `Workspace name: ${workspaceName}`,
+    `Workspace path: ${workspacePath}`,
+    `Current note title: ${documentTitle}`,
+    `Current note path: ${noteRelativePath}`,
+    "Current note body:",
+    "```markdown",
+    documentMarkdown.trimEnd(),
     "```",
-    "",
-    "Conversation history for this note:",
-    renderedHistory,
-    "",
-    "Latest user request:",
-    userMessage.content,
   ].join("\n");
 }
 
-function extractAssistantText(event: Record<string, unknown>) {
-  if (typeof event.delta === "string" && includesAssistantMessage(event.type)) {
-    return {
-      mode: "append" as const,
-      text: event.delta,
-    };
-  }
+async function resumeThread({
+  connection,
+  threadId,
+  threadState,
+  workspacePath,
+}: {
+  connection: AssistantServerConnection;
+  threadId: string;
+  threadState: AssistantThreadState;
+  workspacePath: string;
+}) {
+  const response = await connection.request<{ thread: CodexThread }>("thread/resume", {
+    approvalPolicy: "never",
+    cwd: workspacePath,
+    developerInstructions: DEFAULT_ASSISTANT_INSTRUCTIONS,
+    persistExtendedHistory: true,
+    sandbox: "read-only",
+    threadId,
+  });
+  const resumedThread = mapCodexThreadToAssistantThread({
+    thread: response.thread,
+    workspacePath,
+  });
 
-  const assistantPayload = getAssistantPayload(event);
-  const extractedText = extractTextValue(assistantPayload);
-
-  if (!extractedText) {
-    return null;
-  }
-
-  return {
-    mode: "replace" as const,
-    text: extractedText,
+  threadState.isTurnReady = true;
+  threadState.thread = {
+    ...resumedThread,
+    errorMessage: threadState.thread.errorMessage,
+    messages: threadState.thread.messages,
+    preview: threadState.thread.preview || resumedThread.preview,
+    status: threadState.thread.status,
   };
 }
 
-function getAssistantPayload(event: Record<string, unknown>) {
-  if (event.role === "assistant") {
-    return event.content ?? event.message ?? event.item;
-  }
-
-  if (isRecord(event.message) && event.message.role === "assistant") {
-    return event.message.content ?? event.message;
-  }
-
-  if (isRecord(event.item) && event.item.role === "assistant") {
-    return event.item.content ?? event.item;
-  }
-
-  if (isRecord(event.item) && isAssistantItemType(event.item.type)) {
-    return event.item;
-  }
-
-  if (typeof event.type === "string" && includesAssistantMessage(event.type)) {
-    return event.content ?? event.message ?? event.item;
-  }
-
-  return null;
+function mapCodexThreadToSummary(thread: CodexThread): AssistantThreadSummary {
+  return {
+    createdAt: toIsoTimestamp(thread.createdAt),
+    id: thread.id,
+    preview: getThreadPreview(thread.preview),
+    status: mapCodexStatusToAssistantStatus(thread.status),
+    title: getThreadTitle(thread),
+    updatedAt: toIsoTimestamp(thread.updatedAt),
+  };
 }
 
-function extractTextValue(value: unknown): string | null {
-  if (typeof value === "string") {
-    return value;
-  }
-
-  if (Array.isArray(value)) {
-    const collectedParts = value
-      .map((entry) => extractTextValue(entry))
-      .filter((entry): entry is string => Boolean(entry));
-
-    return collectedParts.length > 0 ? collectedParts.join("") : null;
-  }
-
-  if (!isRecord(value)) {
-    return null;
-  }
-
-  if (typeof value.text === "string") {
-    return value.text;
-  }
-
-  if (typeof value.content === "string") {
-    return value.content;
-  }
-
-  if (Array.isArray(value.content)) {
-    return extractTextValue(value.content);
-  }
-
-  if (isRecord(value.output_text) && typeof value.output_text.text === "string") {
-    return value.output_text.text;
-  }
-
-  return null;
-}
-
-function includesAssistantMessage(type: unknown) {
-  return typeof type === "string" && type.includes("message");
-}
-
-function isAssistantItemType(type: unknown) {
-  return type === "agent_message" || type === "assistant_message";
-}
-
-function getCodexExecArgs(workspacePath: string) {
-  return [
-    "--ask-for-approval",
-    "never",
-    "exec",
-    "--json",
-    "--ephemeral",
-    "--skip-git-repo-check",
-    "--sandbox",
-    "read-only",
-    "-C",
-    workspacePath,
-    "-",
-  ];
-}
-
-function getRunErrorMessage({
-  noteRelativePath,
-  signal,
-  state,
+function mapCodexThreadToAssistantThread({
+  thread,
+  workspacePath,
 }: {
-  noteRelativePath: string;
-  signal: NodeJS.Signals | null;
-  state: AssistantRunState;
-}) {
-  if (signal === "SIGTERM") {
-    return null;
-  }
+  thread: CodexThread;
+  workspacePath: string;
+}): AssistantThread {
+  return {
+    errorMessage: null,
+    id: thread.id,
+    messages: flattenThreadMessages(thread),
+    preview: getThreadPreview(thread.preview),
+    status: mapCodexStatusToAssistantStatus(thread.status),
+    title: getThreadTitle(thread),
+    workspacePath,
+  };
+}
 
-  let lastErrorMessage: string | null = null;
+function flattenThreadMessages(thread: CodexThread): AssistantMessage[] {
+  const messages: AssistantMessage[] = [];
+  const createdAt = toIsoTimestamp(thread.createdAt);
 
-  for (let index = state.lastErrorMessages.length - 1; index >= 0; index -= 1) {
-    const message = state.lastErrorMessages[index];
+  for (const turn of thread.turns) {
+    for (const item of turn.items) {
+      if (isUserMessageItem(item)) {
+        const content = getDisplayUserMessage(item.content);
 
-    if (message && message.length > 0) {
-      lastErrorMessage = message;
-      break;
+        if (!content) {
+          continue;
+        }
+
+        messages.push({
+          content,
+          createdAt,
+          id: item.id,
+          role: "user",
+        });
+      }
+
+      if (isAgentMessageItem(item)) {
+        messages.push({
+          content: item.text,
+          createdAt,
+          id: item.id,
+          role: "assistant",
+        });
+      }
     }
   }
 
-  if (lastErrorMessage) {
-    return lastErrorMessage;
-  }
-
-  return `Codex could not finish responding for ${noteRelativePath}.`;
+  return messages;
 }
 
-function cloneThread(thread: AssistantThread): AssistantThread {
-  return {
-    noteRelativePath: thread.noteRelativePath,
-    messages: thread.messages.map((message) => ({ ...message })),
-    status: thread.status,
-    errorMessage: thread.errorMessage,
-  };
+function getDisplayUserMessage(contentItems: CodexUserInput[]): string {
+  const rawText = contentItems
+    .map((item) => (isTextUserInput(item) ? item.text : ""))
+    .join("\n")
+    .trim();
+
+  return extractMohioUserRequest(rawText) ?? rawText;
 }
 
-function getThreadKey(workspacePath: string, noteRelativePath: string) {
-  return `${workspacePath}::${noteRelativePath}`;
-}
+function extractMohioUserRequest(text: string) {
+  const startIndex = text.indexOf(MOHIO_PROMPT_OPEN);
+  const endIndex = text.indexOf(MOHIO_PROMPT_CLOSE);
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function parseJsonLine(line: string) {
-  const trimmedLine = line.trim();
-
-  if (!trimmedLine.startsWith("{")) {
+  if (startIndex === -1 || endIndex === -1 || endIndex <= startIndex) {
     return null;
   }
 
+  return text
+    .slice(startIndex + MOHIO_PROMPT_OPEN.length, endIndex)
+    .trim();
+}
+
+function getThreadPreview(preview: string) {
+  return extractMohioUserRequest(preview) ?? preview.trim();
+}
+
+function getThreadTitle(thread: CodexThread) {
+  return thread.name?.trim() || getThreadPreview(thread.preview) || "New chat";
+}
+
+function mapCodexStatusToAssistantStatus(status: unknown): AssistantRunStatus {
+  if (!isRecord(status) || typeof status.type !== "string") {
+    return "idle";
+  }
+
+  if (status.type === "active") {
+    return "running";
+  }
+
+  if (status.type === "systemError") {
+    return "error";
+  }
+
+  return "idle";
+}
+
+function getTurnErrorMessage(turnError: unknown) {
+  if (!isRecord(turnError) || typeof turnError.message !== "string") {
+    return "Codex could not complete that run.";
+  }
+
+  if (typeof turnError.additionalDetails === "string" && turnError.additionalDetails.trim()) {
+    return `${turnError.message} ${turnError.additionalDetails}`.trim();
+  }
+
+  return turnError.message;
+}
+
+function getErrorMessage(error: unknown) {
+  if (error instanceof Error && error.message.trim()) {
+    return error.message;
+  }
+
+  return "Mohio could not start the installed Codex app server.";
+}
+
+function isUnmaterializedThreadReadError(error: unknown) {
+  return error instanceof Error &&
+    error.message.includes("is not materialized yet") &&
+    error.message.includes("includeTurns");
+}
+
+function isNoRolloutFoundError(error: unknown) {
+  return error instanceof Error && error.message.includes("no rollout found for thread id");
+}
+
+function parseCodexThread(value: unknown): CodexThread | null {
+  if (!isRecord(value) || typeof value.id !== "string" || typeof value.cwd !== "string") {
+    return null;
+  }
+
+  return value as CodexThread;
+}
+
+function parseJsonLine(line: string): JsonRpcResponse | null {
   try {
-    return JSON.parse(trimmedLine) as unknown;
+    return JSON.parse(line) as JsonRpcResponse;
   } catch {
     return null;
   }
 }
+
+function toIsoTimestamp(unixTimestampSeconds: number) {
+  return new Date(unixTimestampSeconds * 1000).toISOString();
+}
+
+function wait(milliseconds: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+}
+
+function cloneThread(thread: AssistantThread): AssistantThread {
+  return {
+    ...thread,
+    messages: thread.messages.map((message) => ({ ...message })),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return typeof value === "object" && value !== null;
+}
+
+function isAgentMessageItem(item: unknown): item is CodexAgentMessageItem {
+  return isRecord(item) && item.type === "agentMessage" && typeof item.text === "string";
+}
+
+function isUserMessageItem(item: unknown): item is CodexUserMessageItem {
+  return isRecord(item) && item.type === "userMessage" && Array.isArray(item.content);
+}
+
+function isTextUserInput(item: CodexUserInput): item is {
+  type: "text";
+  text: string;
+} {
+  return item.type === "text" && "text" in item && typeof item.text === "string";
+}
+
+interface CodexThread {
+  id: string;
+  preview: string;
+  name: string | null;
+  cwd: string;
+  createdAt: number;
+  updatedAt: number;
+  status: unknown;
+  turns: CodexTurn[];
+}
+
+interface CodexTurn {
+  id: string;
+  items: CodexThreadItem[];
+}
+
+type CodexThreadItem = CodexAgentMessageItem | CodexUserMessageItem | {
+  type: string;
+  id: string;
+};
+
+interface CodexAgentMessageItem {
+  type: "agentMessage";
+  id: string;
+  text: string;
+}
+
+interface CodexUserMessageItem {
+  type: "userMessage";
+  id: string;
+  content: CodexUserInput[];
+}
+
+type CodexUserInput = {
+  type: "text";
+  text: string;
+} | {
+  type: string;
+};

--- a/desktop/src/main/assistant.ts
+++ b/desktop/src/main/assistant.ts
@@ -1,0 +1,580 @@
+import { spawn, type ChildProcessWithoutNullStreams, type SpawnOptionsWithoutStdio } from "node:child_process";
+import { createInterface } from "node:readline";
+import type {
+  AssistantEvent,
+  AssistantMessage,
+  AssistantThread,
+  SendAssistantMessageInput,
+} from "@shared/mohio-types";
+
+const DEFAULT_ASSISTANT_INSTRUCTIONS = [
+  "You are Codex embedded inside Mohio, a local-first Markdown workspace for small teams.",
+  "Work as a chat-only workspace assistant.",
+  "The active note is the primary context, but you may inspect the rest of the workspace when useful.",
+  "Do not propose patches, diffs, or direct file edits in this environment.",
+  "Do not claim to have changed files.",
+  "Respond in concise, practical product language.",
+].join("\n");
+
+type AssistantProcess = Pick<
+  ChildProcessWithoutNullStreams,
+  "kill" | "on" | "stderr" | "stdin" | "stdout"
+>;
+
+type SpawnAssistantProcess = (
+  command: string,
+  args: string[],
+  options: SpawnOptionsWithoutStdio,
+) => AssistantProcess;
+
+interface AssistantRuntimeOptions {
+  createId?: () => string;
+  now?: () => string;
+  spawnProcess?: SpawnAssistantProcess;
+}
+
+interface AssistantRunState {
+  child: AssistantProcess | null;
+  lastErrorMessages: string[];
+  thread: AssistantThread;
+}
+
+interface SendAssistantRunInput extends SendAssistantMessageInput {
+  workspaceName: string;
+  workspacePath: string;
+}
+
+export interface AssistantRuntime {
+  cancelRun: (input: { noteRelativePath: string; workspacePath: string }) => void;
+  getThread: (input: { noteRelativePath: string; workspacePath: string }) => AssistantThread;
+  migrateThread: (input: {
+    fromRelativePath: string;
+    toRelativePath: string;
+    workspacePath: string;
+  }) => void;
+  onThreadChanged: (listener: (event: AssistantEvent) => void) => () => void;
+  sendMessage: (input: SendAssistantRunInput) => AssistantThread;
+}
+
+export function createAssistantRuntime({
+  createId = () => `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+  now = () => new Date().toISOString(),
+  spawnProcess = spawn,
+}: AssistantRuntimeOptions = {}): AssistantRuntime {
+  const listeners = new Set<(event: AssistantEvent) => void>();
+  const threadStates = new Map<string, AssistantRunState>();
+
+  const emitThreadChanged = (workspacePath: string, noteRelativePath: string) => {
+    const thread = cloneThread(getOrCreateThreadState({ noteRelativePath, workspacePath }).thread);
+    const event: AssistantEvent = {
+      workspacePath,
+      noteRelativePath,
+      thread,
+    };
+
+    for (const listener of listeners) {
+      listener(event);
+    }
+  };
+
+  const finalizeRun = ({
+    child,
+    code,
+    noteRelativePath,
+    signal,
+    workspacePath,
+  }: {
+    child: AssistantProcess;
+    code: number | null;
+    noteRelativePath: string;
+    signal: NodeJS.Signals | null;
+    workspacePath: string;
+  }) => {
+    const state = getOrCreateThreadState({ noteRelativePath, workspacePath });
+
+    if (state.child !== child) {
+      return;
+    }
+
+    state.child = null;
+
+    if (code === 0) {
+      state.thread.status = "idle";
+      state.thread.errorMessage = null;
+    } else {
+      state.thread.status = "error";
+      state.thread.errorMessage = getRunErrorMessage({
+        noteRelativePath,
+        signal,
+        state,
+      });
+    }
+
+    emitThreadChanged(workspacePath, noteRelativePath);
+  };
+
+  const handleAssistantEvent = ({
+    event,
+    noteRelativePath,
+    workspacePath,
+  }: {
+    event: unknown;
+    noteRelativePath: string;
+    workspacePath: string;
+  }) => {
+    const state = getOrCreateThreadState({ noteRelativePath, workspacePath });
+    const parsedEvent = isRecord(event) ? event : null;
+
+    if (!parsedEvent) {
+      return;
+    }
+
+    if (parsedEvent.type === "error" && typeof parsedEvent.message === "string") {
+      state.lastErrorMessages.push(parsedEvent.message);
+      return;
+    }
+
+    const delta = extractAssistantText(parsedEvent);
+
+    if (!delta) {
+      return;
+    }
+
+    const assistantMessage = state.thread.messages[state.thread.messages.length - 1];
+
+    if (!assistantMessage || assistantMessage.role !== "assistant") {
+      return;
+    }
+
+    assistantMessage.content = delta.mode === "append"
+      ? `${assistantMessage.content}${delta.text}`
+      : delta.text;
+
+    emitThreadChanged(workspacePath, noteRelativePath);
+  };
+
+  const sendMessage = ({
+    content,
+    documentMarkdown,
+    documentTitle,
+    noteRelativePath,
+    workspaceName,
+    workspacePath,
+  }: SendAssistantRunInput): AssistantThread => {
+    const trimmedContent = content.trim();
+
+    if (!trimmedContent) {
+      throw new Error("Enter a message before asking Codex for help.");
+    }
+
+    const state = getOrCreateThreadState({ noteRelativePath, workspacePath });
+
+    if (state.child) {
+      throw new Error("Wait for the current Codex run to finish.");
+    }
+
+    const userMessage: AssistantMessage = {
+      id: createId(),
+      role: "user",
+      content: trimmedContent,
+      createdAt: now(),
+    };
+    const assistantMessage: AssistantMessage = {
+      id: createId(),
+      role: "assistant",
+      content: "",
+      createdAt: now(),
+    };
+    const prompt = buildAssistantPrompt({
+      documentMarkdown,
+      documentTitle,
+      noteRelativePath,
+      userMessage,
+      workspaceName,
+      workspacePath,
+      historyMessages: [...state.thread.messages, userMessage],
+    });
+
+    state.lastErrorMessages = [];
+    state.thread.messages = [...state.thread.messages, userMessage, assistantMessage];
+    state.thread.status = "running";
+    state.thread.errorMessage = null;
+
+    let child: AssistantProcess;
+
+    try {
+      child = spawnProcess("codex", getCodexExecArgs(workspacePath), {
+        cwd: workspacePath,
+        env: process.env,
+        stdio: "pipe",
+      });
+    } catch {
+      state.thread.status = "error";
+      state.thread.errorMessage = "Mohio could not start the installed Codex CLI.";
+      emitThreadChanged(workspacePath, noteRelativePath);
+      return cloneThread(state.thread);
+    }
+
+    state.child = child;
+    emitThreadChanged(workspacePath, noteRelativePath);
+
+    const stdoutReader = createInterface({ input: child.stdout });
+
+    stdoutReader.on("line", (line) => {
+      const parsedLine = parseJsonLine(line);
+
+      if (!parsedLine) {
+        return;
+      }
+
+      handleAssistantEvent({
+        event: parsedLine,
+        noteRelativePath,
+        workspacePath,
+      });
+    });
+
+    const stderrReader = createInterface({ input: child.stderr });
+    stderrReader.on("line", (line) => {
+      if (line.trim().length > 0) {
+        state.lastErrorMessages.push(line.trim());
+      }
+    });
+
+    child.on("close", (code, signal) => {
+      stdoutReader.close();
+      stderrReader.close();
+      finalizeRun({
+        child,
+        code,
+        noteRelativePath,
+        signal,
+        workspacePath,
+      });
+    });
+
+    child.stdin.write(prompt);
+    child.stdin.end();
+
+    return cloneThread(state.thread);
+  };
+
+  const cancelRun = ({
+    noteRelativePath,
+    workspacePath,
+  }: {
+    noteRelativePath: string;
+    workspacePath: string;
+  }) => {
+    const state = getOrCreateThreadState({ noteRelativePath, workspacePath });
+
+    if (!state.child) {
+      return;
+    }
+
+    const activeChild = state.child;
+    state.child = null;
+    state.lastErrorMessages = [];
+    state.thread.status = "idle";
+    state.thread.errorMessage = null;
+    emitThreadChanged(workspacePath, noteRelativePath);
+
+    try {
+      activeChild.kill("SIGTERM");
+    } catch {
+      // Ignore best-effort shutdown failures.
+    }
+  };
+
+  const migrateThread = ({
+    fromRelativePath,
+    toRelativePath,
+    workspacePath,
+  }: {
+    fromRelativePath: string;
+    toRelativePath: string;
+    workspacePath: string;
+  }) => {
+    if (fromRelativePath === toRelativePath) {
+      return;
+    }
+
+    const previousKey = getThreadKey(workspacePath, fromRelativePath);
+    const nextKey = getThreadKey(workspacePath, toRelativePath);
+    const previousState = threadStates.get(previousKey);
+
+    if (!previousState) {
+      return;
+    }
+
+    previousState.thread.noteRelativePath = toRelativePath;
+    threadStates.set(nextKey, previousState);
+    threadStates.delete(previousKey);
+    emitThreadChanged(workspacePath, toRelativePath);
+  };
+
+  const getThread = ({
+    noteRelativePath,
+    workspacePath,
+  }: {
+    noteRelativePath: string;
+    workspacePath: string;
+  }) => cloneThread(getOrCreateThreadState({ noteRelativePath, workspacePath }).thread);
+
+  const onThreadChanged = (listener: (event: AssistantEvent) => void) => {
+    listeners.add(listener);
+
+    return () => {
+      listeners.delete(listener);
+    };
+  };
+
+  const getOrCreateThreadState = ({
+    noteRelativePath,
+    workspacePath,
+  }: {
+    noteRelativePath: string;
+    workspacePath: string;
+  }): AssistantRunState => {
+    const key = getThreadKey(workspacePath, noteRelativePath);
+    const existingState = threadStates.get(key);
+
+    if (existingState) {
+      return existingState;
+    }
+
+    const nextState: AssistantRunState = {
+      child: null,
+      lastErrorMessages: [],
+      thread: {
+        noteRelativePath,
+        messages: [],
+        status: "idle",
+        errorMessage: null,
+      },
+    };
+
+    threadStates.set(key, nextState);
+    return nextState;
+  };
+
+  return {
+    cancelRun,
+    getThread,
+    migrateThread,
+    onThreadChanged,
+    sendMessage,
+  };
+}
+
+function buildAssistantPrompt({
+  documentMarkdown,
+  documentTitle,
+  historyMessages,
+  noteRelativePath,
+  userMessage,
+  workspaceName,
+  workspacePath,
+}: {
+  documentMarkdown: string;
+  documentTitle: string;
+  historyMessages: AssistantMessage[];
+  noteRelativePath: string;
+  userMessage: AssistantMessage;
+  workspaceName: string;
+  workspacePath: string;
+}) {
+  const renderedHistory = historyMessages.length === 0
+    ? "No previous conversation in this note thread."
+    : historyMessages
+      .map((message) => `${message.role.toUpperCase()}:\n${message.content}`)
+      .join("\n\n");
+
+  return [
+    DEFAULT_ASSISTANT_INSTRUCTIONS,
+    "",
+    "Workspace context:",
+    `- Name: ${workspaceName}`,
+    `- Path: ${workspacePath}`,
+    `- Active note path: ${noteRelativePath}`,
+    `- Active note title: ${documentTitle.trim() || "Untitled"}`,
+    "",
+    "Active note Markdown:",
+    "```md",
+    documentMarkdown,
+    "```",
+    "",
+    "Conversation history for this note:",
+    renderedHistory,
+    "",
+    "Latest user request:",
+    userMessage.content,
+  ].join("\n");
+}
+
+function extractAssistantText(event: Record<string, unknown>) {
+  if (typeof event.delta === "string" && includesAssistantMessage(event.type)) {
+    return {
+      mode: "append" as const,
+      text: event.delta,
+    };
+  }
+
+  const assistantPayload = getAssistantPayload(event);
+  const extractedText = extractTextValue(assistantPayload);
+
+  if (!extractedText) {
+    return null;
+  }
+
+  return {
+    mode: "replace" as const,
+    text: extractedText,
+  };
+}
+
+function getAssistantPayload(event: Record<string, unknown>) {
+  if (event.role === "assistant") {
+    return event.content ?? event.message ?? event.item;
+  }
+
+  if (isRecord(event.message) && event.message.role === "assistant") {
+    return event.message.content ?? event.message;
+  }
+
+  if (isRecord(event.item) && event.item.role === "assistant") {
+    return event.item.content ?? event.item;
+  }
+
+  if (isRecord(event.item) && isAssistantItemType(event.item.type)) {
+    return event.item;
+  }
+
+  if (typeof event.type === "string" && includesAssistantMessage(event.type)) {
+    return event.content ?? event.message ?? event.item;
+  }
+
+  return null;
+}
+
+function extractTextValue(value: unknown): string | null {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    const collectedParts = value
+      .map((entry) => extractTextValue(entry))
+      .filter((entry): entry is string => Boolean(entry));
+
+    return collectedParts.length > 0 ? collectedParts.join("") : null;
+  }
+
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  if (typeof value.text === "string") {
+    return value.text;
+  }
+
+  if (typeof value.content === "string") {
+    return value.content;
+  }
+
+  if (Array.isArray(value.content)) {
+    return extractTextValue(value.content);
+  }
+
+  if (isRecord(value.output_text) && typeof value.output_text.text === "string") {
+    return value.output_text.text;
+  }
+
+  return null;
+}
+
+function includesAssistantMessage(type: unknown) {
+  return typeof type === "string" && type.includes("message");
+}
+
+function isAssistantItemType(type: unknown) {
+  return type === "agent_message" || type === "assistant_message";
+}
+
+function getCodexExecArgs(workspacePath: string) {
+  return [
+    "--ask-for-approval",
+    "never",
+    "exec",
+    "--json",
+    "--ephemeral",
+    "--skip-git-repo-check",
+    "--sandbox",
+    "read-only",
+    "-C",
+    workspacePath,
+    "-",
+  ];
+}
+
+function getRunErrorMessage({
+  noteRelativePath,
+  signal,
+  state,
+}: {
+  noteRelativePath: string;
+  signal: NodeJS.Signals | null;
+  state: AssistantRunState;
+}) {
+  if (signal === "SIGTERM") {
+    return null;
+  }
+
+  let lastErrorMessage: string | null = null;
+
+  for (let index = state.lastErrorMessages.length - 1; index >= 0; index -= 1) {
+    const message = state.lastErrorMessages[index];
+
+    if (message && message.length > 0) {
+      lastErrorMessage = message;
+      break;
+    }
+  }
+
+  if (lastErrorMessage) {
+    return lastErrorMessage;
+  }
+
+  return `Codex could not finish responding for ${noteRelativePath}.`;
+}
+
+function cloneThread(thread: AssistantThread): AssistantThread {
+  return {
+    noteRelativePath: thread.noteRelativePath,
+    messages: thread.messages.map((message) => ({ ...message })),
+    status: thread.status,
+    errorMessage: thread.errorMessage,
+  };
+}
+
+function getThreadKey(workspacePath: string, noteRelativePath: string) {
+  return `${workspacePath}::${noteRelativePath}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function parseJsonLine(line: string) {
+  const trimmedLine = line.trim();
+
+  if (!trimmedLine.startsWith("{")) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(trimmedLine) as unknown;
+  } catch {
+    return null;
+  }
+}

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -4,12 +4,14 @@ import { app, BrowserWindow, Menu, dialog, ipcMain } from "electron";
 import type { BaseWindow, IpcMainInvokeEvent, WebContents } from "electron";
 import path from "node:path";
 import { MOHIO_CHANNELS } from "@shared/mohio-api";
-import type { DocumentChangedEvent, WorkspaceSummary } from "@shared/mohio-types";
+import type { AssistantEvent, DocumentChangedEvent, WorkspaceSummary } from "@shared/mohio-types";
+import { createAssistantRuntime } from "./assistant";
 import { readDocument, resolveWorkspacePath, saveDocument } from "./document-store";
 import { buildAppMenuTemplate } from "./menu";
 import { getWorkspaceSummary } from "./workspace";
 
 let currentWorkspacePath: string | null = null;
+const assistantRuntime = createAssistantRuntime();
 const activeDocumentWatches = new Map<number, {
   absolutePath: string;
   listener: (currentStats: Stats, previousStats: Stats) => void;
@@ -62,6 +64,12 @@ async function loadCurrentWorkspace() {
 function broadcastWorkspaceChange(workspace: WorkspaceSummary | null) {
   for (const window of BrowserWindow.getAllWindows()) {
     window.webContents.send(MOHIO_CHANNELS.workspaceChanged, workspace);
+  }
+}
+
+function broadcastAssistantEvent(event: AssistantEvent) {
+  for (const window of BrowserWindow.getAllWindows()) {
+    window.webContents.send(MOHIO_CHANNELS.assistantEvent, event);
   }
 }
 
@@ -178,10 +186,55 @@ function registerMohioHandlers() {
       throw new Error("Open a workspace before saving documents.");
     }
 
-    return saveDocument(currentWorkspacePath, input);
+    const result = await saveDocument(currentWorkspacePath, input);
+
+    assistantRuntime.migrateThread({
+      workspacePath: currentWorkspacePath,
+      fromRelativePath: input.relativePath,
+      toRelativePath: result.relativePath,
+    });
+
+    return result;
   });
   ipcMain.handle(MOHIO_CHANNELS.watchDocument, async (event, relativePath: string | null) => {
     watchDocumentForEventSender(event, relativePath);
+  });
+  ipcMain.handle(MOHIO_CHANNELS.getAssistantThread, async (_event, noteRelativePath: string) => {
+    if (!currentWorkspacePath) {
+      throw new Error("Open a workspace before starting an assistant conversation.");
+    }
+
+    return assistantRuntime.getThread({
+      workspacePath: currentWorkspacePath,
+      noteRelativePath,
+    });
+  });
+  ipcMain.handle(MOHIO_CHANNELS.sendAssistantMessage, async (_event, input) => {
+    if (!currentWorkspacePath) {
+      throw new Error("Open a workspace before starting an assistant conversation.");
+    }
+
+    const workspace = await loadCurrentWorkspace();
+
+    if (!workspace) {
+      throw new Error("Open a workspace before starting an assistant conversation.");
+    }
+
+    return assistantRuntime.sendMessage({
+      workspacePath: currentWorkspacePath,
+      workspaceName: workspace.name,
+      ...input,
+    });
+  });
+  ipcMain.handle(MOHIO_CHANNELS.cancelAssistantRun, async (_event, noteRelativePath: string) => {
+    if (!currentWorkspacePath) {
+      return;
+    }
+
+    assistantRuntime.cancelRun({
+      workspacePath: currentWorkspacePath,
+      noteRelativePath,
+    });
   });
 }
 
@@ -197,6 +250,9 @@ function registerApplicationMenu() {
 
 app.whenReady().then(() => {
   app.setName("Mohio");
+  assistantRuntime.onThreadChanged((event) => {
+    broadcastAssistantEvent(event);
+  });
   registerMohioHandlers();
   registerApplicationMenu();
   const mainWindow = createMainWindow();

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -186,27 +186,37 @@ function registerMohioHandlers() {
       throw new Error("Open a workspace before saving documents.");
     }
 
-    const result = await saveDocument(currentWorkspacePath, input);
-
-    assistantRuntime.migrateThread({
-      workspacePath: currentWorkspacePath,
-      fromRelativePath: input.relativePath,
-      toRelativePath: result.relativePath,
-    });
-
-    return result;
+    return saveDocument(currentWorkspacePath, input);
   });
   ipcMain.handle(MOHIO_CHANNELS.watchDocument, async (event, relativePath: string | null) => {
     watchDocumentForEventSender(event, relativePath);
   });
-  ipcMain.handle(MOHIO_CHANNELS.getAssistantThread, async (_event, noteRelativePath: string) => {
+  ipcMain.handle(MOHIO_CHANNELS.listAssistantThreads, async () => {
+    if (!currentWorkspacePath) {
+      throw new Error("Open a workspace before starting an assistant conversation.");
+    }
+
+    return assistantRuntime.listThreads({
+      workspacePath: currentWorkspacePath,
+    });
+  });
+  ipcMain.handle(MOHIO_CHANNELS.createAssistantThread, async () => {
+    if (!currentWorkspacePath) {
+      throw new Error("Open a workspace before starting an assistant conversation.");
+    }
+
+    return assistantRuntime.createThread({
+      workspacePath: currentWorkspacePath,
+    });
+  });
+  ipcMain.handle(MOHIO_CHANNELS.getAssistantThread, async (_event, threadId: string) => {
     if (!currentWorkspacePath) {
       throw new Error("Open a workspace before starting an assistant conversation.");
     }
 
     return assistantRuntime.getThread({
+      threadId,
       workspacePath: currentWorkspacePath,
-      noteRelativePath,
     });
   });
   ipcMain.handle(MOHIO_CHANNELS.sendAssistantMessage, async (_event, input) => {
@@ -226,14 +236,35 @@ function registerMohioHandlers() {
       ...input,
     });
   });
-  ipcMain.handle(MOHIO_CHANNELS.cancelAssistantRun, async (_event, noteRelativePath: string) => {
+  ipcMain.handle(MOHIO_CHANNELS.cancelAssistantRun, async (_event, threadId: string) => {
     if (!currentWorkspacePath) {
       return;
     }
 
-    assistantRuntime.cancelRun({
+    await assistantRuntime.cancelRun({
+      threadId,
       workspacePath: currentWorkspacePath,
-      noteRelativePath,
+    });
+  });
+  ipcMain.handle(MOHIO_CHANNELS.renameAssistantThread, async (_event, input) => {
+    if (!currentWorkspacePath) {
+      throw new Error("Open a workspace before renaming an assistant conversation.");
+    }
+
+    await assistantRuntime.renameThread({
+      threadId: input.threadId,
+      title: input.title,
+      workspacePath: currentWorkspacePath,
+    });
+  });
+  ipcMain.handle(MOHIO_CHANNELS.deleteAssistantThread, async (_event, threadId: string) => {
+    if (!currentWorkspacePath) {
+      throw new Error("Open a workspace before deleting an assistant conversation.");
+    }
+
+    await assistantRuntime.deleteThread({
+      threadId,
+      workspacePath: currentWorkspacePath,
     });
   });
 }
@@ -250,7 +281,7 @@ function registerApplicationMenu() {
 
 app.whenReady().then(() => {
   app.setName("Mohio");
-  assistantRuntime.onThreadChanged((event) => {
+  assistantRuntime.onEvent((event) => {
     broadcastAssistantEvent(event);
   });
   registerMohioHandlers();

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -13,6 +13,12 @@ const mohioApi = createMohioApi({
   readDocument: (relativePath) => ipcRenderer.invoke(MOHIO_CHANNELS.readDocument, relativePath),
   saveDocument: (input) => ipcRenderer.invoke(MOHIO_CHANNELS.saveDocument, input),
   watchDocument: (relativePath) => ipcRenderer.invoke(MOHIO_CHANNELS.watchDocument, relativePath),
+  getAssistantThread: (noteRelativePath) =>
+    ipcRenderer.invoke(MOHIO_CHANNELS.getAssistantThread, noteRelativePath),
+  sendAssistantMessage: (input) =>
+    ipcRenderer.invoke(MOHIO_CHANNELS.sendAssistantMessage, input),
+  cancelAssistantRun: (noteRelativePath) =>
+    ipcRenderer.invoke(MOHIO_CHANNELS.cancelAssistantRun, noteRelativePath),
   onDocumentChanged: (listener) => {
     const handleDocumentChanged = (
       _event: Electron.IpcRendererEvent,
@@ -39,6 +45,20 @@ const mohioApi = createMohioApi({
 
     return () => {
       ipcRenderer.removeListener(MOHIO_CHANNELS.workspaceChanged, handleWorkspaceChanged);
+    };
+  },
+  onAssistantEvent: (listener) => {
+    const handleAssistantEvent = (
+      _event: Electron.IpcRendererEvent,
+      assistantEvent: Awaited<ReturnType<typeof ipcRenderer.invoke>>,
+    ) => {
+      listener(assistantEvent);
+    };
+
+    ipcRenderer.on(MOHIO_CHANNELS.assistantEvent, handleAssistantEvent);
+
+    return () => {
+      ipcRenderer.removeListener(MOHIO_CHANNELS.assistantEvent, handleAssistantEvent);
     };
   },
 });

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -13,12 +13,20 @@ const mohioApi = createMohioApi({
   readDocument: (relativePath) => ipcRenderer.invoke(MOHIO_CHANNELS.readDocument, relativePath),
   saveDocument: (input) => ipcRenderer.invoke(MOHIO_CHANNELS.saveDocument, input),
   watchDocument: (relativePath) => ipcRenderer.invoke(MOHIO_CHANNELS.watchDocument, relativePath),
-  getAssistantThread: (noteRelativePath) =>
-    ipcRenderer.invoke(MOHIO_CHANNELS.getAssistantThread, noteRelativePath),
+  listAssistantThreads: () =>
+    ipcRenderer.invoke(MOHIO_CHANNELS.listAssistantThreads),
+  createAssistantThread: () =>
+    ipcRenderer.invoke(MOHIO_CHANNELS.createAssistantThread),
+  getAssistantThread: (threadId) =>
+    ipcRenderer.invoke(MOHIO_CHANNELS.getAssistantThread, threadId),
   sendAssistantMessage: (input) =>
     ipcRenderer.invoke(MOHIO_CHANNELS.sendAssistantMessage, input),
-  cancelAssistantRun: (noteRelativePath) =>
-    ipcRenderer.invoke(MOHIO_CHANNELS.cancelAssistantRun, noteRelativePath),
+  cancelAssistantRun: (threadId) =>
+    ipcRenderer.invoke(MOHIO_CHANNELS.cancelAssistantRun, threadId),
+  renameAssistantThread: (input) =>
+    ipcRenderer.invoke(MOHIO_CHANNELS.renameAssistantThread, input),
+  deleteAssistantThread: (threadId) =>
+    ipcRenderer.invoke(MOHIO_CHANNELS.deleteAssistantThread, threadId),
   onDocumentChanged: (listener) => {
     const handleDocumentChanged = (
       _event: Electron.IpcRendererEvent,

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type {
+  AssistantThread,
   WorkspaceDocument,
   WorkspaceDocumentNode,
   WorkspaceSummary,
@@ -8,6 +9,12 @@ import type {
 import { RichTextEditor } from "./markdown-editor";
 
 type SaveState = "error" | "idle" | "loading" | "saved" | "saving";
+
+const ASSISTANT_QUICK_ACTIONS = [
+  "Summarize this note",
+  "Organize this note",
+  "Suggest related notes from this workspace",
+] as const;
 
 interface DocumentSnapshot {
   markdown: string;
@@ -27,6 +34,10 @@ export function App() {
   const [draftMarkdown, setDraftMarkdown] = useState("");
   const [documentError, setDocumentError] = useState<string | null>(null);
   const [saveState, setSaveState] = useState<SaveState>("idle");
+  const [assistantThread, setAssistantThread] = useState<AssistantThread | null>(null);
+  const [assistantComposerValue, setAssistantComposerValue] = useState("");
+  const [assistantError, setAssistantError] = useState<string | null>(null);
+  const [isAssistantLoading, setIsAssistantLoading] = useState(false);
   const lastSavedSnapshotRef = useRef<DocumentSnapshot | null>(null);
   const pendingSaveSnapshotRef = useRef<DocumentSnapshot | null>(null);
   const loadSequenceRef = useRef(0);
@@ -35,11 +46,14 @@ export function App() {
   const saveStateRef = useRef<SaveState>("idle");
   const draftTitleRef = useRef("");
   const draftMarkdownRef = useRef("");
+  const workspacePathRef = useRef<string | null>(null);
+  const assistantBodyRef = useRef<HTMLDivElement | null>(null);
 
   selectedDocumentIdRef.current = selectedDocumentId;
   saveStateRef.current = saveState;
   draftTitleRef.current = draftTitle;
   draftMarkdownRef.current = draftMarkdown;
+  workspacePathRef.current = workspace?.path ?? null;
 
   useEffect(() => {
     let isMounted = true;
@@ -212,6 +226,73 @@ export function App() {
     };
   }, []);
 
+  useEffect(() => {
+    if (!workspace || !selectedDocumentId) {
+      setAssistantThread(null);
+      setAssistantError(null);
+      setIsAssistantLoading(false);
+      return;
+    }
+
+    let isMounted = true;
+    setIsAssistantLoading(true);
+    setAssistantError(null);
+
+    void window.mohio.getAssistantThread(selectedDocumentId).then(
+      (thread) => {
+        if (!isMounted) {
+          return;
+        }
+
+        setAssistantThread(thread);
+        setAssistantError(thread.errorMessage);
+        setIsAssistantLoading(false);
+      },
+      () => {
+        if (!isMounted) {
+          return;
+        }
+
+        setAssistantThread(getEmptyAssistantThread(selectedDocumentId));
+        setAssistantError("Mohio could not load the assistant conversation.");
+        setIsAssistantLoading(false);
+      },
+    );
+
+    return () => {
+      isMounted = false;
+    };
+  }, [selectedDocumentId, workspace]);
+
+  useEffect(() => {
+    const disposeAssistantListener = window.mohio.onAssistantEvent((event) => {
+      if (
+        event.workspacePath !== workspacePathRef.current ||
+        event.noteRelativePath !== selectedDocumentIdRef.current
+      ) {
+        return;
+      }
+
+      setAssistantThread(event.thread);
+      setAssistantError(event.thread.errorMessage);
+      setIsAssistantLoading(false);
+    });
+
+    return () => {
+      disposeAssistantListener();
+    };
+  }, []);
+
+  useEffect(() => {
+    const assistantBody = assistantBodyRef.current;
+
+    if (!assistantBody) {
+      return;
+    }
+
+    assistantBody.scrollTop = assistantBody.scrollHeight;
+  }, [assistantThread?.messages, assistantThread?.status, isAssistantLoading]);
+
   const isDirty = useMemo(() => {
     const lastSavedSnapshot = lastSavedSnapshotRef.current;
 
@@ -343,6 +424,49 @@ export function App() {
     });
   };
 
+  const handleSendAssistantMessage = async (message: string) => {
+    const trimmedMessage = message.trim();
+
+    if (!workspace || !selectedDocumentId || !document || trimmedMessage.length === 0) {
+      return;
+    }
+
+    setAssistantComposerValue("");
+    setAssistantError(null);
+
+    try {
+      const nextThread = await window.mohio.sendAssistantMessage({
+        noteRelativePath: selectedDocumentId,
+        content: trimmedMessage,
+        documentTitle: draftTitle,
+        documentMarkdown: draftMarkdown,
+      });
+
+      setAssistantThread(nextThread);
+    } catch {
+      setAssistantError("Mohio could not start Codex for this workspace.");
+    }
+  };
+
+  const handleCancelAssistantRun = async () => {
+    if (!selectedDocumentId) {
+      return;
+    }
+
+    try {
+      await window.mohio.cancelAssistantRun(selectedDocumentId);
+    } catch {
+      setAssistantError("Mohio could not stop the current Codex run.");
+    }
+  };
+
+  const assistantHasContext = Boolean(workspace && selectedDocumentId && document);
+  const assistantIsBusy = assistantThread?.status === "running";
+  const canSendAssistantMessage =
+    assistantHasContext &&
+    !assistantIsBusy &&
+    assistantComposerValue.trim().length > 0;
+
   return (
     <div className="app-shell">
       <header className="top-bar" data-testid="top-bar">
@@ -464,22 +588,111 @@ export function App() {
         <aside className="sidebar sidebar--right" data-testid="assistant-sidebar">
           <section className="sidebar__section assistant-panel-header">
             <p className="assistant-panel__label">Assistant</p>
+            {!workspace || !selectedDocumentId ? (
+              <p className="workspace-panel__copy">Open a workspace note to chat with Codex</p>
+            ) : null}
           </section>
 
-          <div className="assistant-panel__body" />
+          <div
+            ref={assistantBodyRef}
+            className="assistant-panel__body"
+            data-testid="assistant-transcript"
+          >
+            {!workspace ? null : !selectedDocumentId || !document ? (
+              <p className="assistant-panel__copy">
+                Select a note to open a note-specific assistant thread.
+              </p>
+            ) : isAssistantLoading ? (
+              <p className="assistant-panel__copy">Loading the conversation for this note...</p>
+            ) : assistantThread && assistantThread.messages.length > 0 ? (
+              <ol className="assistant-message-list" aria-live="polite">
+                {assistantThread.messages.map((message) => (
+                  <li
+                    className={`assistant-message assistant-message--${message.role}`}
+                    key={message.id}
+                  >
+                    <p className="assistant-message__role">
+                      {message.role === "assistant" ? "Codex" : "You"}
+                    </p>
+                    <p className="assistant-message__content">
+                      {message.content || (message.role === "assistant" && assistantIsBusy ? "Thinking..." : "")}
+                    </p>
+                  </li>
+                ))}
+              </ol>
+            ) : null}
+          </div>
 
           <div className="assistant-panel__footer">
             <section className="sidebar__section">
               <ul className="action-list">
-                <li>Summarize note</li>
-                <li>Discover related notes</li>
-                <li>Resolve conflicting notes</li>
+                {ASSISTANT_QUICK_ACTIONS.map((action) => (
+                  <li key={action}>
+                    <button
+                      className="assistant-action-chip"
+                      disabled={!assistantHasContext || assistantIsBusy}
+                      onClick={() => {
+                        void handleSendAssistantMessage(action);
+                      }}
+                      type="button"
+                    >
+                      {action}
+                    </button>
+                  </li>
+                ))}
               </ul>
             </section>
 
-            <div className="chat-composer" aria-label="Assistant composer">
-              Ask Mohio for help
-            </div>
+            {assistantError ? (
+              <p className="workspace-panel__error" role="status">
+                {assistantError}
+              </p>
+            ) : null}
+
+            <form
+              className="assistant-composer"
+              onSubmit={(event) => {
+                event.preventDefault();
+                void handleSendAssistantMessage(assistantComposerValue);
+              }}
+            >
+              <input
+                aria-label="Assistant composer"
+                className="chat-composer"
+                data-testid="assistant-composer-input"
+                disabled={!assistantHasContext || assistantIsBusy}
+                onChange={(event) => {
+                  setAssistantComposerValue(event.target.value);
+                }}
+                placeholder={
+                  assistantHasContext
+                    ? "Ask Codex about this note or workspace"
+                    : "Select a note to chat with Codex"
+                }
+                type="text"
+                value={assistantComposerValue}
+              />
+
+              <div className="assistant-composer__actions">
+                <button
+                  className="ghost-button"
+                  disabled={!assistantIsBusy}
+                  onClick={() => {
+                    void handleCancelAssistantRun();
+                  }}
+                  type="button"
+                >
+                  Cancel
+                </button>
+                <button
+                  className="primary-button"
+                  disabled={!canSendAssistantMessage}
+                  type="submit"
+                >
+                  Send
+                </button>
+              </div>
+            </form>
           </div>
         </aside>
       </div>
@@ -668,6 +881,15 @@ function snapshotsMatch(
     left.title === right.title &&
     left.markdown === right.markdown
   );
+}
+
+function getEmptyAssistantThread(noteRelativePath: string): AssistantThread {
+  return {
+    noteRelativePath,
+    messages: [],
+    status: "idle",
+    errorMessage: null,
+  };
 }
 
 function ChevronDownIcon() {

--- a/desktop/src/renderer/App.tsx
+++ b/desktop/src/renderer/App.tsx
@@ -1,6 +1,15 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  ArrowLeft,
+  ChevronDown,
+  ChevronRight,
+  Ellipsis,
+  MessageSquarePlus,
+  SquarePen,
+} from "lucide-react";
 import type {
   AssistantThread,
+  AssistantThreadSummary,
   WorkspaceDocument,
   WorkspaceDocumentNode,
   WorkspaceSummary,
@@ -9,6 +18,8 @@ import type {
 import { RichTextEditor } from "./markdown-editor";
 
 type SaveState = "error" | "idle" | "loading" | "saved" | "saving";
+type AssistantView = "list" | "thread";
+const THINKING_LABEL_DELAY_MS = 900;
 
 const ASSISTANT_QUICK_ACTIONS = [
   "Summarize this note",
@@ -34,22 +45,36 @@ export function App() {
   const [draftMarkdown, setDraftMarkdown] = useState("");
   const [documentError, setDocumentError] = useState<string | null>(null);
   const [saveState, setSaveState] = useState<SaveState>("idle");
+  const [assistantThreads, setAssistantThreads] = useState<AssistantThreadSummary[]>([]);
+  const [assistantView, setAssistantView] = useState<AssistantView>("list");
+  const [activeAssistantThreadId, setActiveAssistantThreadId] = useState<string | null>(null);
   const [assistantThread, setAssistantThread] = useState<AssistantThread | null>(null);
   const [assistantComposerValue, setAssistantComposerValue] = useState("");
   const [assistantError, setAssistantError] = useState<string | null>(null);
-  const [isAssistantLoading, setIsAssistantLoading] = useState(false);
+  const [isAssistantMenuOpen, setIsAssistantMenuOpen] = useState(false);
+  const [isAssistantListLoading, setIsAssistantListLoading] = useState(false);
+  const [isAssistantThreadLoading, setIsAssistantThreadLoading] = useState(false);
+  const [showAssistantThinking, setShowAssistantThinking] = useState(false);
   const lastSavedSnapshotRef = useRef<DocumentSnapshot | null>(null);
   const pendingSaveSnapshotRef = useRef<DocumentSnapshot | null>(null);
   const loadSequenceRef = useRef(0);
   const saveSequenceRef = useRef(0);
   const selectedDocumentIdRef = useRef<string | null>(null);
+  const activeAssistantThreadIdRef = useRef<string | null>(null);
+  const assistantViewRef = useRef<AssistantView>("list");
+  const assistantThreadRef = useRef<AssistantThread | null>(null);
   const saveStateRef = useRef<SaveState>("idle");
   const draftTitleRef = useRef("");
   const draftMarkdownRef = useRef("");
   const workspacePathRef = useRef<string | null>(null);
   const assistantBodyRef = useRef<HTMLDivElement | null>(null);
+  const assistantThinkingTimerRef = useRef<number | null>(null);
+  const lastAssistantStreamSignatureRef = useRef<string | null>(null);
 
   selectedDocumentIdRef.current = selectedDocumentId;
+  activeAssistantThreadIdRef.current = activeAssistantThreadId;
+  assistantViewRef.current = assistantView;
+  assistantThreadRef.current = assistantThread;
   saveStateRef.current = saveState;
   draftTitleRef.current = draftTitle;
   draftMarkdownRef.current = draftMarkdown;
@@ -227,18 +252,68 @@ export function App() {
   }, []);
 
   useEffect(() => {
-    if (!workspace || !selectedDocumentId) {
+    if (!workspace) {
+      setAssistantThreads([]);
+      setAssistantView("list");
+      setActiveAssistantThreadId(null);
       setAssistantThread(null);
       setAssistantError(null);
-      setIsAssistantLoading(false);
+      setIsAssistantMenuOpen(false);
+      setIsAssistantListLoading(false);
+      setIsAssistantThreadLoading(false);
+      setShowAssistantThinking(false);
       return;
     }
 
     let isMounted = true;
-    setIsAssistantLoading(true);
+    setIsAssistantListLoading(true);
     setAssistantError(null);
 
-    void window.mohio.getAssistantThread(selectedDocumentId).then(
+    void window.mohio.listAssistantThreads().then(
+      (threads) => {
+        if (!isMounted) {
+          return;
+        }
+
+        setAssistantThreads(threads);
+        setActiveAssistantThreadId((currentThreadId) =>
+          getPreferredAssistantThreadId(threads, currentThreadId),
+        );
+        setAssistantView("list");
+        setIsAssistantListLoading(false);
+      },
+      () => {
+        if (!isMounted) {
+          return;
+        }
+
+        setAssistantThreads([]);
+        setAssistantView("list");
+        setActiveAssistantThreadId(null);
+        setAssistantThread(null);
+        setAssistantError("Mohio could not load Codex chat history for this workspace.");
+        setIsAssistantListLoading(false);
+      },
+    );
+
+    return () => {
+      isMounted = false;
+    };
+  }, [workspace]);
+
+  useEffect(() => {
+    if (!workspace || !activeAssistantThreadId) {
+      setAssistantThread(null);
+      setAssistantError(null);
+      setIsAssistantThreadLoading(false);
+      return;
+    }
+
+    let isMounted = true;
+    setIsAssistantThreadLoading(true);
+    setAssistantError(null);
+
+    void window.mohio.getAssistantThread(activeAssistantThreadId).then(
       (thread) => {
         if (!isMounted) {
           return;
@@ -246,36 +321,60 @@ export function App() {
 
         setAssistantThread(thread);
         setAssistantError(thread.errorMessage);
-        setIsAssistantLoading(false);
+        setIsAssistantThreadLoading(false);
       },
       () => {
         if (!isMounted) {
           return;
         }
 
-        setAssistantThread(getEmptyAssistantThread(selectedDocumentId));
-        setAssistantError("Mohio could not load the assistant conversation.");
-        setIsAssistantLoading(false);
+        setAssistantThread(null);
+        setAssistantError("Mohio could not load the selected Codex chat.");
+        setIsAssistantThreadLoading(false);
       },
     );
 
     return () => {
       isMounted = false;
     };
-  }, [selectedDocumentId, workspace]);
+  }, [activeAssistantThreadId, workspace]);
 
   useEffect(() => {
     const disposeAssistantListener = window.mohio.onAssistantEvent((event) => {
-      if (
-        event.workspacePath !== workspacePathRef.current ||
-        event.noteRelativePath !== selectedDocumentIdRef.current
-      ) {
+      if (event.workspacePath !== workspacePathRef.current) {
+        return;
+      }
+
+      if (event.type === "thread-list") {
+        setAssistantThreads(event.threads);
+        setActiveAssistantThreadId((currentThreadId) => {
+          const nextThreadId = getPreferredAssistantThreadId(event.threads, currentThreadId);
+
+          const shouldKeepTransientThread = Boolean(
+            currentThreadId &&
+            assistantViewRef.current === "thread" &&
+            assistantThreadRef.current?.id === currentThreadId,
+          );
+
+          if (!nextThreadId && !shouldKeepTransientThread) {
+            setAssistantThread(null);
+            setAssistantView("list");
+            setIsAssistantMenuOpen(false);
+          }
+
+          return shouldKeepTransientThread ? currentThreadId : nextThreadId;
+        });
+        setIsAssistantListLoading(false);
+        return;
+      }
+
+      if (event.thread.id !== activeAssistantThreadIdRef.current) {
         return;
       }
 
       setAssistantThread(event.thread);
       setAssistantError(event.thread.errorMessage);
-      setIsAssistantLoading(false);
+      setIsAssistantThreadLoading(false);
     });
 
     return () => {
@@ -291,7 +390,58 @@ export function App() {
     }
 
     assistantBody.scrollTop = assistantBody.scrollHeight;
-  }, [assistantThread?.messages, assistantThread?.status, isAssistantLoading]);
+  }, [assistantThread?.messages, assistantThread?.status, isAssistantThreadLoading, showAssistantThinking]);
+
+  useEffect(() => {
+    const clearThinkingTimer = () => {
+      if (assistantThinkingTimerRef.current === null) {
+        return;
+      }
+
+      window.clearTimeout(assistantThinkingTimerRef.current);
+      assistantThinkingTimerRef.current = null;
+    };
+
+    const activeThread = assistantThread;
+    const lastAssistantMessage = getLastAssistantMessage(activeThread);
+    const streamSignature = activeThread && lastAssistantMessage
+      ? `${activeThread.id}:${lastAssistantMessage.id}:${lastAssistantMessage.content}`
+      : activeThread
+        ? `${activeThread.id}:none`
+        : null;
+
+    if (!activeThread || activeThread.status !== "running") {
+      clearThinkingTimer();
+      setShowAssistantThinking(false);
+      lastAssistantStreamSignatureRef.current = streamSignature;
+
+      return () => {
+        clearThinkingTimer();
+      };
+    }
+
+    const hasVisibleAssistantContent = Boolean(lastAssistantMessage?.content);
+    const contentChanged = streamSignature !== lastAssistantStreamSignatureRef.current;
+
+    clearThinkingTimer();
+
+    if (!hasVisibleAssistantContent) {
+      setShowAssistantThinking(true);
+    } else if (contentChanged) {
+      setShowAssistantThinking(false);
+      assistantThinkingTimerRef.current = window.setTimeout(() => {
+        if (assistantThreadRef.current?.status === "running") {
+          setShowAssistantThinking(true);
+        }
+      }, THINKING_LABEL_DELAY_MS);
+    }
+
+    lastAssistantStreamSignatureRef.current = streamSignature;
+
+    return () => {
+      clearThinkingTimer();
+    };
+  }, [assistantThread]);
 
   const isDirty = useMemo(() => {
     const lastSavedSnapshot = lastSavedSnapshotRef.current;
@@ -424,6 +574,39 @@ export function App() {
     });
   };
 
+  const handleCreateAssistantThread = async () => {
+    if (!workspace) {
+      return null;
+    }
+
+    setAssistantError(null);
+    setIsAssistantMenuOpen(false);
+
+    try {
+      const nextThread = await window.mohio.createAssistantThread();
+
+      setAssistantThreads((currentThreads) => [
+        {
+          createdAt: new Date().toISOString(),
+          id: nextThread.id,
+          preview: nextThread.preview,
+          status: nextThread.status,
+          title: nextThread.title,
+          updatedAt: new Date().toISOString(),
+        },
+        ...currentThreads.filter((thread) => thread.id !== nextThread.id),
+      ]);
+      setActiveAssistantThreadId(nextThread.id);
+      setAssistantThread(nextThread);
+      setAssistantView("thread");
+
+      return nextThread;
+    } catch {
+      setAssistantError("Mohio could not create a new Codex chat for this workspace.");
+      return null;
+    }
+  };
+
   const handleSendAssistantMessage = async (message: string) => {
     const trimmedMessage = message.trim();
 
@@ -435,37 +618,129 @@ export function App() {
     setAssistantError(null);
 
     try {
+      const shouldStartNewThread = assistantViewRef.current === "list";
+      const currentThread = shouldStartNewThread
+        ? await handleCreateAssistantThread()
+        : (assistantThread ?? await handleCreateAssistantThread());
+
+      if (!currentThread) {
+        return;
+      }
+
       const nextThread = await window.mohio.sendAssistantMessage({
+        threadId: currentThread.id,
         noteRelativePath: selectedDocumentId,
         content: trimmedMessage,
         documentTitle: draftTitle,
         documentMarkdown: draftMarkdown,
       });
 
+      setActiveAssistantThreadId(nextThread.id);
       setAssistantThread(nextThread);
+      setAssistantView("thread");
     } catch {
-      setAssistantError("Mohio could not start Codex for this workspace.");
+      setAssistantError("Mohio could not send that message to the selected Codex chat.");
     }
   };
 
   const handleCancelAssistantRun = async () => {
-    if (!selectedDocumentId) {
+    if (!activeAssistantThreadId) {
       return;
     }
 
     try {
-      await window.mohio.cancelAssistantRun(selectedDocumentId);
+      await window.mohio.cancelAssistantRun(activeAssistantThreadId);
     } catch {
       setAssistantError("Mohio could not stop the current Codex run.");
     }
   };
 
+  const handleOpenAssistantThread = (threadId: string) => {
+    setAssistantError(null);
+    setIsAssistantMenuOpen(false);
+    setActiveAssistantThreadId(threadId);
+    setAssistantView("thread");
+  };
+
+  const handleRenameAssistantThread = async () => {
+    if (!activeAssistantThreadId) {
+      return;
+    }
+
+    const currentTitle = assistantThread?.title || "New Chat";
+    const nextTitle = window.prompt("Rename Chat", currentTitle)?.trim();
+
+    if (!nextTitle) {
+      return;
+    }
+
+    setAssistantError(null);
+    setIsAssistantMenuOpen(false);
+
+    try {
+      await window.mohio.renameAssistantThread({
+        threadId: activeAssistantThreadId,
+        title: nextTitle,
+      });
+      setAssistantThread((currentThread) => (
+        currentThread ? { ...currentThread, title: nextTitle } : currentThread
+      ));
+      setAssistantThreads((currentThreads) =>
+        currentThreads.map((thread) => (
+          thread.id === activeAssistantThreadId
+            ? { ...thread, title: nextTitle }
+            : thread
+        )),
+      );
+    } catch {
+      setAssistantError("Mohio could not rename this Codex chat.");
+    }
+  };
+
+  const handleDeleteAssistantThread = async () => {
+    if (!activeAssistantThreadId) {
+      return;
+    }
+
+    const confirmed = window.confirm("Delete this chat from the visible workspace list?");
+
+    if (!confirmed) {
+      return;
+    }
+
+    const threadId = activeAssistantThreadId;
+
+    setAssistantError(null);
+    setIsAssistantMenuOpen(false);
+
+    try {
+      await window.mohio.deleteAssistantThread(threadId);
+      setAssistantThreads((currentThreads) =>
+        currentThreads.filter((thread) => thread.id !== threadId),
+      );
+      setActiveAssistantThreadId(null);
+      setAssistantThread(null);
+      setAssistantView("list");
+    } catch {
+      setAssistantError("Mohio could not delete this Codex chat.");
+    }
+  };
+
   const assistantHasContext = Boolean(workspace && selectedDocumentId && document);
   const assistantIsBusy = assistantThread?.status === "running";
+  const assistantIsDetailView = assistantView === "thread";
+  const assistantVisibleMessages = assistantThread?.messages.filter((message) =>
+    message.role === "user" || message.content.trim().length > 0
+  ) ?? [];
+  const activeAssistantThreadSummary = assistantThreads.find(
+    (thread) => thread.id === activeAssistantThreadId,
+  ) ?? null;
+  const assistantThreadTitle = assistantThread?.title || activeAssistantThreadSummary?.title || "New Chat";
   const canSendAssistantMessage =
     assistantHasContext &&
     !assistantIsBusy &&
     assistantComposerValue.trim().length > 0;
+  const showAssistantFooter = assistantIsDetailView || Boolean(workspace);
 
   return (
     <div className="app-shell">
@@ -481,10 +756,10 @@ export function App() {
             type="button"
           >
             <span className="workspace-label__name">
-              {workspace?.name ?? "Open a workspace"}
+              {workspace?.name ?? "Open Workspace"}
             </span>
             <span className="workspace-label__chevron" aria-hidden="true">
-              <ChevronDownIcon />
+              <ChevronDown aria-hidden="true" className="toolbar-chevron-icon" />
             </span>
           </button>
         </div>
@@ -505,7 +780,17 @@ export function App() {
       <div className="workspace-shell">
         <aside className="sidebar sidebar--left" data-testid="workspace-sidebar">
           <section className="sidebar__section">
-            <h2 className="sidebar__title">Workspace</h2>
+            <div className="assistant-panel-header__row">
+              <h2 className="sidebar__title">Workspace</h2>
+              <button
+                aria-label="New Note"
+                className="assistant-panel__text-icon-button workspace-panel__new-note"
+                disabled
+                type="button"
+              >
+                <SquarePen aria-hidden="true" className="assistant-panel__icon assistant-panel__icon--new-chat" />
+              </button>
+            </div>
 
             {isWorkspaceLoading ? (
               <p className="workspace-panel__copy">Loading current workspace...</p>
@@ -572,7 +857,7 @@ export function App() {
                   }}
                   type="button"
                 >
-                  {isWorkspaceOpening ? "Opening Workspace ..." : "Choose folder"}
+                  {isWorkspaceOpening ? "Opening Workspace..." : "Open Workspace"}
                 </button>
               </section>
             )}
@@ -586,114 +871,239 @@ export function App() {
         </main>
 
         <aside className="sidebar sidebar--right" data-testid="assistant-sidebar">
-          <section className="sidebar__section assistant-panel-header">
-            <p className="assistant-panel__label">Assistant</p>
-            {!workspace || !selectedDocumentId ? (
-              <p className="workspace-panel__copy">Open a workspace note to chat with Codex</p>
-            ) : null}
-          </section>
-
-          <div
-            ref={assistantBodyRef}
-            className="assistant-panel__body"
-            data-testid="assistant-transcript"
-          >
-            {!workspace ? null : !selectedDocumentId || !document ? (
-              <p className="assistant-panel__copy">
-                Select a note to open a note-specific assistant thread.
-              </p>
-            ) : isAssistantLoading ? (
-              <p className="assistant-panel__copy">Loading the conversation for this note...</p>
-            ) : assistantThread && assistantThread.messages.length > 0 ? (
-              <ol className="assistant-message-list" aria-live="polite">
-                {assistantThread.messages.map((message) => (
-                  <li
-                    className={`assistant-message assistant-message--${message.role}`}
-                    key={message.id}
-                  >
-                    <p className="assistant-message__role">
-                      {message.role === "assistant" ? "Codex" : "You"}
-                    </p>
-                    <p className="assistant-message__content">
-                      {message.content || (message.role === "assistant" && assistantIsBusy ? "Thinking..." : "")}
-                    </p>
-                  </li>
-                ))}
-              </ol>
-            ) : null}
-          </div>
-
-          <div className="assistant-panel__footer">
-            <section className="sidebar__section">
-              <ul className="action-list">
-                {ASSISTANT_QUICK_ACTIONS.map((action) => (
-                  <li key={action}>
+          {assistantIsDetailView ? (
+            <>
+              <section className="sidebar__section assistant-panel-header assistant-panel-header--detail">
+                <div className="assistant-panel-header__row">
+                  <div className="assistant-panel-header__main">
                     <button
-                      className="assistant-action-chip"
-                      disabled={!assistantHasContext || assistantIsBusy}
+                      aria-label="Back to chats"
+                      className="assistant-panel__text-icon-button"
                       onClick={() => {
-                        void handleSendAssistantMessage(action);
+                        setAssistantView("list");
+                        setIsAssistantMenuOpen(false);
                       }}
                       type="button"
                     >
-                      {action}
+                      <ArrowLeft aria-hidden="true" className="assistant-panel__icon" />
                     </button>
-                  </li>
-                ))}
-              </ul>
-            </section>
+                    <div className="assistant-panel-header__title-group">
+                      <p className="assistant-panel__label">Assistant</p>
+                      <h2 className="assistant-panel__thread-title">{assistantThreadTitle}</h2>
+                    </div>
+                  </div>
 
-            {assistantError ? (
-              <p className="workspace-panel__error" role="status">
-                {assistantError}
-              </p>
-            ) : null}
+                  <div className="assistant-panel__menu">
+                    <button
+                      aria-expanded={isAssistantMenuOpen}
+                      aria-haspopup="menu"
+                      aria-label="Chat options"
+                      className="assistant-panel__text-icon-button"
+                      onClick={() => {
+                        setIsAssistantMenuOpen((currentState) => !currentState);
+                      }}
+                      type="button"
+                    >
+                      <Ellipsis aria-hidden="true" className="assistant-panel__icon" />
+                    </button>
 
-            <form
-              className="assistant-composer"
-              onSubmit={(event) => {
-                event.preventDefault();
-                void handleSendAssistantMessage(assistantComposerValue);
-              }}
-            >
-              <input
-                aria-label="Assistant composer"
-                className="chat-composer"
-                data-testid="assistant-composer-input"
-                disabled={!assistantHasContext || assistantIsBusy}
-                onChange={(event) => {
-                  setAssistantComposerValue(event.target.value);
-                }}
-                placeholder={
-                  assistantHasContext
-                    ? "Ask Codex about this note or workspace"
-                    : "Select a note to chat with Codex"
-                }
-                type="text"
-                value={assistantComposerValue}
-              />
+                    {isAssistantMenuOpen ? (
+                      <div
+                        className="assistant-panel__menu-popover"
+                        role="menu"
+                      >
+                        <button
+                          className="assistant-panel__menu-item"
+                          disabled={!workspace || assistantIsBusy}
+                          onClick={() => {
+                            void handleCreateAssistantThread();
+                          }}
+                          role="menuitem"
+                          type="button"
+                        >
+                          New Chat
+                        </button>
+                        <button
+                          className="assistant-panel__menu-item"
+                          onClick={() => {
+                            void handleRenameAssistantThread();
+                          }}
+                          role="menuitem"
+                          type="button"
+                        >
+                          Rename Chat
+                        </button>
+                        <button
+                          className="assistant-panel__menu-item assistant-panel__menu-item--danger"
+                          onClick={() => {
+                            void handleDeleteAssistantThread();
+                          }}
+                          role="menuitem"
+                          type="button"
+                        >
+                          Delete Chat
+                        </button>
+                      </div>
+                    ) : null}
+                  </div>
+                </div>
+              </section>
 
-              <div className="assistant-composer__actions">
-                <button
-                  className="ghost-button"
-                  disabled={!assistantIsBusy}
-                  onClick={() => {
-                    void handleCancelAssistantRun();
-                  }}
-                  type="button"
-                >
-                  Cancel
-                </button>
-                <button
-                  className="primary-button"
-                  disabled={!canSendAssistantMessage}
-                  type="submit"
-                >
-                  Send
-                </button>
+              <div
+                ref={assistantBodyRef}
+                className="assistant-panel__body"
+                data-testid="assistant-transcript"
+              >
+                {!workspace ? null : !selectedDocumentId || !document ? (
+                  <p className="assistant-panel__copy">
+                    Select a note before asking Codex about this workspace.
+                  </p>
+                ) : isAssistantThreadLoading ? (
+                  <p className="assistant-panel__copy">Loading the selected Codex chat...</p>
+                ) : assistantVisibleMessages.length > 0 ? (
+                  <ol className="assistant-message-list" aria-live="polite">
+                    {assistantVisibleMessages.map((message) => (
+                      <li
+                        className={`assistant-message assistant-message--${message.role}`}
+                        key={message.id}
+                      >
+                        <p className="assistant-message__role">
+                          {message.role === "assistant" ? "Codex" : "You"}
+                        </p>
+                        <p className="assistant-message__content">{message.content}</p>
+                      </li>
+                    ))}
+                  </ol>
+                ) : null}
+
+                {showAssistantThinking ? (
+                  <p className="assistant-thinking-indicator" aria-live="polite">
+                    Thinking...
+                  </p>
+                ) : null}
               </div>
-            </form>
-          </div>
+            </>
+          ) : (
+            <>
+              <section className="sidebar__section assistant-panel-header">
+                <div className="assistant-panel-header__row">
+                  <p className="assistant-panel__label">Assistant</p>
+                  <button
+                    aria-label="New Chat"
+                    className="assistant-panel__text-icon-button assistant-panel__new-chat"
+                    disabled={!workspace || assistantIsBusy}
+                    onClick={() => {
+                      void handleCreateAssistantThread();
+                    }}
+                    type="button"
+                  >
+                    <MessageSquarePlus aria-hidden="true" className="assistant-panel__icon assistant-panel__icon--new-chat" />
+                  </button>
+                </div>
+                {!workspace || !selectedDocumentId ? (
+                  <p className="workspace-panel__copy">Open a workspace to chat with the assistant</p>
+                ) : null}
+              </section>
+
+              <section className="sidebar__section assistant-thread-list-section">
+                {isAssistantListLoading ? (
+                  <p className="workspace-panel__copy">Loading Codex chat history...</p>
+                ) : !workspace ? null : assistantThreads.length > 0 ? (
+                  <ul className="assistant-thread-list" data-testid="assistant-thread-list">
+                    {assistantThreads.map((thread) => (
+                      <li key={thread.id}>
+                        <button
+                          className="assistant-thread-list__button"
+                          onClick={() => {
+                            handleOpenAssistantThread(thread.id);
+                          }}
+                          type="button"
+                        >
+                          <span className="assistant-thread-list__title">{thread.title || "New Chat"}</span>
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="workspace-panel__copy">No Codex chats yet for this workspace.</p>
+                )}
+              </section>
+            </>
+          )}
+
+          {showAssistantFooter ? (
+            <div className="assistant-panel__footer">
+              <section className="sidebar__section">
+                <ul className="action-list">
+                  {ASSISTANT_QUICK_ACTIONS.map((action) => (
+                    <li key={action}>
+                      <button
+                        className="assistant-action-chip"
+                        disabled={!assistantHasContext || assistantIsBusy}
+                        onClick={() => {
+                          void handleSendAssistantMessage(action);
+                        }}
+                        type="button"
+                      >
+                        {action}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+
+              {assistantError ? (
+                <p className="workspace-panel__error" role="status">
+                  {assistantError}
+                </p>
+              ) : null}
+
+              <form
+                className="assistant-composer"
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  void handleSendAssistantMessage(assistantComposerValue);
+                }}
+              >
+                <input
+                  aria-label="Assistant composer"
+                  className="chat-composer"
+                  data-testid="assistant-composer-input"
+                  disabled={!assistantHasContext || assistantIsBusy}
+                  onChange={(event) => {
+                    setAssistantComposerValue(event.target.value);
+                  }}
+                  placeholder={
+                    assistantHasContext
+                      ? "Ask Codex about this note or workspace"
+                      : "Select a note to chat with Codex"
+                  }
+                  type="text"
+                  value={assistantComposerValue}
+                />
+
+                <div className="assistant-composer__actions">
+                  <button
+                    className="ghost-button"
+                    disabled={!assistantIsBusy}
+                    onClick={() => {
+                      void handleCancelAssistantRun();
+                    }}
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    className="primary-button"
+                    disabled={!canSendAssistantMessage}
+                    type="submit"
+                  >
+                    Send
+                  </button>
+                </div>
+              </form>
+            </div>
+          ) : null}
         </aside>
       </div>
     </div>
@@ -734,7 +1144,11 @@ function renderWorkspaceNode({
           type="button"
         >
           <span className="tree-node__chevron" aria-hidden="true">
-            <TreeChevronIcon isExpanded={isExpanded} />
+            {isExpanded ? (
+              <ChevronDown aria-hidden="true" className="tree-chevron-icon" />
+            ) : (
+              <ChevronRight aria-hidden="true" className="tree-chevron-icon" />
+            )}
           </span>
           <span className="tree-node__label">{node.name}</span>
         </button>
@@ -811,6 +1225,22 @@ function getPreferredDocumentId(
   return findFirstDocumentId(workspace.documents);
 }
 
+function getLastAssistantMessage(thread: AssistantThread | null) {
+  if (!thread) {
+    return null;
+  }
+
+  for (let index = thread.messages.length - 1; index >= 0; index -= 1) {
+    const message = thread.messages[index];
+
+    if (message.role === "assistant") {
+      return message;
+    }
+  }
+
+  return null;
+}
+
 function findFirstDocumentId(nodes: WorkspaceTreeNode[]): string | null {
   for (const node of nodes) {
     if (node.kind === "document") {
@@ -883,41 +1313,15 @@ function snapshotsMatch(
   );
 }
 
-function getEmptyAssistantThread(noteRelativePath: string): AssistantThread {
-  return {
-    noteRelativePath,
-    messages: [],
-    status: "idle",
-    errorMessage: null,
-  };
-}
+function getPreferredAssistantThreadId(
+  threads: AssistantThreadSummary[],
+  preferredThreadId?: string | null,
+): string | null {
+  if (preferredThreadId && threads.some((thread) => thread.id === preferredThreadId)) {
+    return preferredThreadId;
+  }
 
-function ChevronDownIcon() {
-  return (
-    <svg aria-hidden="true" className="toolbar-chevron-icon" fill="none" viewBox="0 0 16 16">
-      <path
-        d="M4.5 6.5 8 10l3.5-3.5"
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth="1.35"
-      />
-    </svg>
-  );
-}
-
-function TreeChevronIcon({ isExpanded }: { isExpanded: boolean }) {
-  return (
-    <svg aria-hidden="true" className="tree-chevron-icon" fill="none" viewBox="0 0 16 16">
-      <path
-        d={isExpanded ? "M4.75 6.5 8 9.75 11.25 6.5" : "M6.5 4.75 9.75 8 6.5 11.25"}
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth="1.45"
-      />
-    </svg>
-  );
+  return null;
 }
 
 export default App;

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -749,7 +749,7 @@ button {
 }
 
 .assistant-panel-header {
-  gap: 0;
+  gap: 6px;
   flex: 0 0 auto;
 }
 
@@ -778,12 +778,103 @@ button {
 }
 
 .action-list li {
+  list-style: none;
+}
+
+.assistant-action-chip {
   border: 1px solid var(--border);
   border-radius: 999px;
   background: var(--background);
   padding: 10px 14px;
   font-size: 14px;
   color: var(--text-secondary);
+  transition:
+    background-color 120ms ease,
+    color 120ms ease,
+    border-color 120ms ease;
+}
+
+.assistant-action-chip:hover:not(:disabled) {
+  border-color: rgba(37, 99, 235, 0.22);
+  background: var(--accent-blue-soft);
+  color: var(--accent-blue);
+}
+
+.assistant-action-chip:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.assistant-message-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.assistant-message {
+  display: flex;
+  max-width: calc(100% - 20px);
+  flex-direction: column;
+  gap: 6px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px 14px;
+}
+
+.assistant-message--assistant {
+  align-self: flex-start;
+  background: var(--background);
+}
+
+.assistant-message--user {
+  align-self: flex-end;
+  background: var(--accent-blue-soft);
+  border-color: rgba(37, 99, 235, 0.12);
+}
+
+.assistant-message__role {
+  margin: 0;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.assistant-message__content {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-primary);
+}
+
+.assistant-composer {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.assistant-composer__actions {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.assistant-composer__actions .primary-button,
+.assistant-composer__actions .ghost-button {
+  flex: 1 1 0;
+}
+
+.ghost-button:disabled,
+.primary-button:disabled,
+.chat-composer:disabled {
+  cursor: default;
+  opacity: 0.6;
 }
 
 @media (max-width: 1200px) {

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -753,6 +753,150 @@ button {
   flex: 0 0 auto;
 }
 
+.assistant-panel-header--detail {
+  padding-bottom: 6px;
+}
+
+.assistant-panel-header__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.assistant-panel-header__main {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 10px;
+}
+
+.assistant-panel-header__title-group {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.assistant-panel__thread-title {
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.35;
+  color: var(--text-primary);
+}
+
+.assistant-panel__new-chat {
+  padding: 0;
+  font-size: 0;
+}
+
+.assistant-panel__text-icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: transparent;
+  padding: 0;
+  color: var(--text-muted);
+}
+
+.assistant-panel__text-icon-button:hover:not(:disabled) {
+  color: var(--text-primary);
+}
+
+.assistant-panel__icon {
+  width: 16px;
+  height: 16px;
+}
+
+.assistant-panel__icon--new-chat {
+  width: 18px;
+  height: 18px;
+}
+
+.assistant-panel__menu {
+  position: relative;
+  flex: 0 0 auto;
+}
+
+.assistant-panel__menu-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 3;
+  display: flex;
+  min-width: 168px;
+  flex-direction: column;
+  padding: 6px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--background);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+
+.assistant-panel__menu-item {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  padding: 9px 10px;
+  text-align: left;
+  color: var(--text-secondary);
+}
+
+.assistant-panel__menu-item:hover:not(:disabled) {
+  background: var(--muted-surface);
+  color: var(--text-primary);
+}
+
+.assistant-panel__menu-item--danger {
+  color: #b91c1c;
+}
+
+.assistant-thread-list-section {
+  min-height: 0;
+  flex: 1;
+}
+
+.assistant-thread-list {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  flex-direction: column;
+  gap: 2px;
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+  list-style: none;
+}
+
+.assistant-thread-list__button {
+  display: block;
+  width: 100%;
+  border: none;
+  background: transparent;
+  padding: 8px 0;
+  text-align: left;
+  color: var(--text-secondary);
+}
+
+.assistant-thread-list__button:hover {
+  color: var(--text-primary);
+}
+
+.assistant-thread-list__title {
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.35;
+  color: currentColor;
+}
+
 .assistant-panel__body {
   display: flex;
   min-height: 0;
@@ -816,23 +960,24 @@ button {
 
 .assistant-message {
   display: flex;
-  max-width: calc(100% - 20px);
+  width: 100%;
   flex-direction: column;
   gap: 6px;
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 12px 14px;
+  padding: 0 10px;
 }
 
 .assistant-message--assistant {
-  align-self: flex-start;
-  background: var(--background);
+  align-items: flex-start;
 }
 
 .assistant-message--user {
   align-self: flex-end;
+  width: auto;
+  max-width: calc(100% - 28px);
+  border: 1px solid rgba(37, 99, 235, 0.12);
+  border-radius: 12px;
   background: var(--accent-blue-soft);
-  border-color: rgba(37, 99, 235, 0.12);
+  padding: 12px 14px;
 }
 
 .assistant-message__role {
@@ -844,6 +989,10 @@ button {
   color: var(--text-muted);
 }
 
+.assistant-message--assistant .assistant-message__role {
+  padding-left: 2px;
+}
+
 .assistant-message__content {
   margin: 0;
   white-space: pre-wrap;
@@ -851,6 +1000,15 @@ button {
   font-size: 14px;
   line-height: 1.6;
   color: var(--text-primary);
+}
+
+.assistant-thinking-indicator {
+  margin: 0;
+  padding: 0 10px;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-muted);
+  animation: assistant-thinking 1.35s ease-in-out infinite;
 }
 
 .assistant-composer {
@@ -872,9 +1030,28 @@ button {
 
 .ghost-button:disabled,
 .primary-button:disabled,
-.chat-composer:disabled {
+.chat-composer:disabled,
+.assistant-panel__text-icon-button:disabled,
+.assistant-panel__menu-item:disabled {
   cursor: default;
   opacity: 0.6;
+}
+
+@keyframes assistant-thinking {
+  0% {
+    opacity: 0.4;
+    transform: translateX(0);
+  }
+
+  50% {
+    opacity: 0.9;
+    transform: translateX(2px);
+  }
+
+  100% {
+    opacity: 0.4;
+    transform: translateX(0);
+  }
 }
 
 @media (max-width: 1200px) {

--- a/desktop/src/renderer/test/App.test.tsx
+++ b/desktop/src/renderer/test/App.test.tsx
@@ -1,26 +1,65 @@
 import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import type {
+  AssistantEvent,
+  AssistantThread,
+  DocumentChangedEvent,
+  MohioApi,
+  WorkspaceSummary,
+} from "@shared/mohio-types";
 import App from "@renderer/App";
+
+function createAssistantThread(
+  noteRelativePath: string,
+  overrides: Partial<AssistantThread> = {},
+): AssistantThread {
+  return {
+    noteRelativePath,
+    messages: [],
+    status: "idle",
+    errorMessage: null,
+    ...overrides,
+  };
+}
+
+function createMohioMock(overrides: Partial<MohioApi> = {}): MohioApi {
+  return {
+    getAppInfo: () => ({
+      name: "Mohio",
+      version: "0.1.0",
+      platform: "darwin",
+    }),
+    getCurrentWorkspace: async () => null,
+    openWorkspace: async () => null,
+    readDocument: async () => {
+      throw new Error("No document");
+    },
+    saveDocument: async () => {
+      throw new Error("No document");
+    },
+    watchDocument: async () => undefined,
+    getAssistantThread: async (noteRelativePath) => createAssistantThread(noteRelativePath),
+    sendAssistantMessage: async (input) => createAssistantThread(input.noteRelativePath, {
+      messages: [
+        {
+          id: "user-1",
+          role: "user",
+          content: input.content,
+          createdAt: "2026-03-22T00:00:00.000Z",
+        },
+      ],
+      status: "running",
+    }),
+    cancelAssistantRun: async () => undefined,
+    onDocumentChanged: () => () => undefined,
+    onWorkspaceChanged: () => () => undefined,
+    onAssistantEvent: () => () => undefined,
+    ...overrides,
+  };
+}
 
 describe("App", () => {
   it("renders the empty workspace shell", async () => {
-    window.mohio = {
-      getAppInfo: () => ({
-        name: "Mohio",
-        version: "0.1.0",
-        platform: "darwin",
-      }),
-      getCurrentWorkspace: async () => null,
-      openWorkspace: async () => null,
-      readDocument: async () => {
-        throw new Error("No document");
-      },
-      saveDocument: async () => {
-        throw new Error("No document");
-      },
-      watchDocument: async () => undefined,
-      onDocumentChanged: () => () => undefined,
-      onWorkspaceChanged: () => () => undefined,
-    };
+    window.mohio = createMohioMock();
 
     render(<App />);
 
@@ -34,57 +73,22 @@ describe("App", () => {
     expect(await screen.findByTestId("document-state")).toHaveTextContent("Choose a folder to open your Mohio workspace.");
     expect(screen.getByText("No workspace is open.")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Choose folder" })).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Open folder" })).not.toBeInTheDocument();
-    expect(screen.queryByText("Documents")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Heading 1" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Heading styles" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Heading 3" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Bold" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Underline" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Italic" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Text styles" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Bulleted list" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Numbered list" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Text alignment" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Alignment options" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Align center" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Align right" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Justify" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Table" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Clear formatting" })).not.toBeInTheDocument();
     expect(screen.getByText("Assistant")).toBeInTheDocument();
-    expect(screen.queryByText("Ready for guided document work")).not.toBeInTheDocument();
-    expect(screen.queryByText("Suggested actions")).not.toBeInTheDocument();
-    expect(screen.getByText("Summarize note")).toBeInTheDocument();
-    expect(screen.getByText("Discover related notes")).toBeInTheDocument();
-    expect(screen.getByText("Resolve conflicting notes")).toBeInTheDocument();
-    expect(within(topBar).queryByText("Open a workspace")).toBeInTheDocument();
-    expect(within(topBar).queryByRole("button", { name: "New note" })).not.toBeInTheDocument();
-    expect(within(topBar).queryByRole("button", { name: "Publish" })).not.toBeInTheDocument();
+    expect(screen.getByText("Open a workspace note to chat with Codex")).toBeInTheDocument();
+    expect(screen.queryByText("Codex chat")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Open a workspace to start chatting with Codex inside Mohio."),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Summarize this note" })).toBeDisabled();
+    expect(screen.getByLabelText("Assistant composer")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
   });
 
-  it("renders the workspace tree and switches workspaces through the shared API", async () => {
-    let onDocumentChangedListener: ((event: {
-      relativePath: string;
-      document: {
-        relativePath: string;
-        fileName: string;
-        displayTitle: string;
-        markdown: string;
-      } | null;
-      workspace: {
-        name: string;
-        path: string;
-        documentCount: number;
-        documents: Array<{
-          id: string;
-          kind: "document";
-          name: string;
-          relativePath: string;
-          displayTitle: string;
-        }>;
-      } | null;
-    }) => void) | null = null;
+  it("renders the workspace tree, switches workspaces, and loads note assistant state", async () => {
+    let onDocumentChangedListener: ((event: DocumentChangedEvent) => void) | null = null;
+    let onAssistantEventListener: ((event: AssistantEvent) => void) | null = null;
     const getCurrentWorkspace = vi.fn().mockResolvedValue({
       name: "alpha",
       path: "/workspaces/alpha",
@@ -120,8 +124,7 @@ describe("App", () => {
           displayTitle: "ROADMAP",
         },
       ],
-    });
-
+    } satisfies WorkspaceSummary);
     const openWorkspace = vi.fn().mockResolvedValue({
       name: "beta",
       path: "/workspaces/beta",
@@ -135,7 +138,7 @@ describe("App", () => {
           displayTitle: "Team Handbook",
         },
       ],
-    });
+    } satisfies WorkspaceSummary);
     const readDocument = vi.fn()
       .mockResolvedValueOnce({
         relativePath: "docs/Architecture.md",
@@ -149,34 +152,41 @@ describe("App", () => {
         displayTitle: "Team Handbook",
         markdown: "Beta body.\n",
       });
-    const saveDocument = vi.fn().mockResolvedValue({
-      relativePath: "docs/Architecture.md",
-      fileName: "Architecture.md",
-      displayTitle: "Architecture Overview",
-      markdown: "Current body.\n",
-      savedAt: "2026-03-21T00:00:00.000Z",
-    });
-    const watchDocument = vi.fn().mockResolvedValue(undefined);
+    const getAssistantThread = vi.fn().mockImplementation(async (noteRelativePath: string) => {
+      if (noteRelativePath === "Team Handbook.md") {
+        return createAssistantThread("Team Handbook.md", {
+          messages: [
+            {
+              id: "assistant-1",
+              role: "assistant",
+              content: "Beta workspace summary.",
+              createdAt: "2026-03-22T00:00:00.000Z",
+            },
+          ],
+        });
+      }
 
-    window.mohio = {
-      getAppInfo: () => ({
-        name: "Mohio",
-        version: "0.1.0",
-        platform: "darwin",
-      }),
+      return createAssistantThread(noteRelativePath);
+    });
+
+    window.mohio = createMohioMock({
       getCurrentWorkspace,
       openWorkspace,
       readDocument,
-      saveDocument,
-      watchDocument,
+      getAssistantThread,
       onDocumentChanged: (listener) => {
         onDocumentChangedListener = listener;
         return () => {
           onDocumentChangedListener = null;
         };
       },
-      onWorkspaceChanged: () => () => undefined,
-    };
+      onAssistantEvent: (listener) => {
+        onAssistantEventListener = listener;
+        return () => {
+          onAssistantEventListener = null;
+        };
+      },
+    });
 
     render(<App />);
 
@@ -184,24 +194,16 @@ describe("App", () => {
       await screen.findByRole("button", { name: "Switch workspace from alpha" }),
     ).toHaveTextContent("alpha");
     const docsFolderToggle = screen.getByRole("button", { name: "docs" });
-    expect(screen.queryByText("/workspaces/alpha")).not.toBeInTheDocument();
     expect(docsFolderToggle).toHaveAttribute("aria-expanded", "true");
     expect(screen.getByRole("button", { name: "Architecture Overview" })).toHaveAttribute("aria-current", "page");
-    expect(screen.getByRole("button", { name: "README" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "ROADMAP" })).toBeInTheDocument();
     expect(await screen.findByLabelText("Document title")).toHaveValue("Architecture Overview");
-    expect(screen.queryByText("docs/Architecture.md")).not.toBeInTheDocument();
-    expect(watchDocument).toHaveBeenCalledWith("docs/Architecture.md");
+    expect(screen.queryByText("alpha · docs/Architecture.md")).not.toBeInTheDocument();
+    expect(getAssistantThread).toHaveBeenCalledWith("docs/Architecture.md");
 
     fireEvent.click(docsFolderToggle);
-
     expect(docsFolderToggle).toHaveAttribute("aria-expanded", "false");
-    expect(screen.queryByRole("button", { name: "Architecture Overview" })).not.toBeInTheDocument();
-
     fireEvent.click(docsFolderToggle);
-
     expect(docsFolderToggle).toHaveAttribute("aria-expanded", "true");
-    expect(screen.getByRole("button", { name: "Architecture Overview" })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Switch workspace from alpha" }));
 
@@ -209,17 +211,13 @@ describe("App", () => {
     expect(
       await screen.findByRole("button", { name: "Switch workspace from beta" }),
     ).toHaveTextContent("beta");
-    expect(screen.queryByText("/workspaces/beta")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Team Handbook" })).toHaveAttribute("aria-current", "page");
     expect(await screen.findByLabelText("Document title")).toHaveValue("Team Handbook");
-    expect(screen.queryByText("Team Handbook.md")).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Heading 1" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Strikethrough" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Horizontal rule" })).toBeInTheDocument();
-    expect(saveDocument).not.toHaveBeenCalled();
-    expect(watchDocument).toHaveBeenLastCalledWith("Team Handbook.md");
+    expect(screen.queryByText("beta · Team Handbook.md")).not.toBeInTheDocument();
+    expect(screen.getByText("Beta workspace summary.")).toBeInTheDocument();
 
     expect(onDocumentChangedListener).not.toBeNull();
+    expect(onAssistantEventListener).not.toBeNull();
 
     await act(async () => {
       onDocumentChangedListener?.({
@@ -248,32 +246,30 @@ describe("App", () => {
     });
 
     expect(await screen.findByLabelText("Document title")).toHaveValue("Team Handbook Updated");
-    expect(screen.getByRole("button", { name: "Team Handbook Updated" })).toHaveAttribute("aria-current", "page");
+
+    await act(async () => {
+      onAssistantEventListener?.({
+        workspacePath: "/workspaces/beta",
+        noteRelativePath: "Team Handbook.md",
+        thread: createAssistantThread("Team Handbook.md", {
+          messages: [
+            {
+              id: "assistant-2",
+              role: "assistant",
+              content: "Updated assistant context.",
+              createdAt: "2026-03-22T00:01:00.000Z",
+            },
+          ],
+        }),
+      });
+    });
+
+    expect(screen.getByText("Updated assistant context.")).toBeInTheDocument();
   });
 
   it("keeps newer local edits when a file-watch event arrives for Mohio's own older save", async () => {
     try {
-      let onDocumentChangedListener: ((event: {
-        relativePath: string;
-        document: {
-          relativePath: string;
-          fileName: string;
-          displayTitle: string;
-          markdown: string;
-        } | null;
-        workspace: {
-          name: string;
-          path: string;
-          documentCount: number;
-          documents: Array<{
-            id: string;
-            kind: "document";
-            name: string;
-            relativePath: string;
-            displayTitle: string;
-          }>;
-        } | null;
-      }) => void) | null = null;
+      let onDocumentChangedListener: ((event: DocumentChangedEvent) => void) | null = null;
       let resolveSaveDocument: ((value: {
         relativePath: string;
         fileName: string;
@@ -288,12 +284,7 @@ describe("App", () => {
           }),
       );
 
-      window.mohio = {
-        getAppInfo: () => ({
-          name: "Mohio",
-          version: "0.1.0",
-          platform: "darwin",
-        }),
+      window.mohio = createMohioMock({
         getCurrentWorkspace: async () => ({
           name: "alpha",
           path: "/workspaces/alpha",
@@ -308,7 +299,6 @@ describe("App", () => {
             },
           ],
         }),
-        openWorkspace: async () => null,
         readDocument: async () => ({
           relativePath: "Team Handbook.md",
           fileName: "Team Handbook.md",
@@ -316,15 +306,13 @@ describe("App", () => {
           markdown: "Initial body.\n",
         }),
         saveDocument,
-        watchDocument: async () => undefined,
         onDocumentChanged: (listener) => {
           onDocumentChangedListener = listener;
           return () => {
             onDocumentChangedListener = null;
           };
         },
-        onWorkspaceChanged: () => () => undefined,
-      };
+      });
 
       render(<App />);
 
@@ -388,4 +376,142 @@ describe("App", () => {
       vi.useRealTimers();
     }
   }, 10000);
+
+  it("sends assistant messages, streams updates, and keeps note conversations separate", async () => {
+    let onAssistantEventListener: ((event: AssistantEvent) => void) | null = null;
+    const sendAssistantMessage = vi.fn().mockImplementation(async (input) =>
+      createAssistantThread(input.noteRelativePath, {
+        messages: [
+          {
+            id: "user-1",
+            role: "user",
+            content: input.content,
+            createdAt: "2026-03-22T00:00:00.000Z",
+          },
+          {
+            id: "assistant-1",
+            role: "assistant",
+            content: "",
+            createdAt: "2026-03-22T00:00:00.000Z",
+          },
+        ],
+        status: "running",
+      }),
+    );
+    const getAssistantThread = vi.fn().mockImplementation(async (noteRelativePath) =>
+      createAssistantThread(noteRelativePath),
+    );
+
+    window.mohio = createMohioMock({
+      getCurrentWorkspace: async () => ({
+        name: "alpha",
+        path: "/workspaces/alpha",
+        documentCount: 2,
+        documents: [
+          {
+            id: "docs/Architecture.md",
+            kind: "document",
+            name: "Architecture.md",
+            relativePath: "docs/Architecture.md",
+            displayTitle: "Architecture Overview",
+          },
+          {
+            id: "README.md",
+            kind: "document",
+            name: "README.md",
+            relativePath: "README.md",
+            displayTitle: "README",
+          },
+        ],
+      }),
+      readDocument: vi.fn()
+        .mockResolvedValueOnce({
+          relativePath: "docs/Architecture.md",
+          fileName: "Architecture.md",
+          displayTitle: "Architecture Overview",
+          markdown: "Current body.\n",
+        })
+        .mockResolvedValueOnce({
+          relativePath: "README.md",
+          fileName: "README.md",
+          displayTitle: "README",
+          markdown: "Readme body.\n",
+        }),
+      getAssistantThread,
+      sendAssistantMessage,
+      cancelAssistantRun: vi.fn().mockResolvedValue(undefined),
+      onAssistantEvent: (listener) => {
+        onAssistantEventListener = listener;
+        return () => {
+          onAssistantEventListener = null;
+        };
+      },
+    });
+
+    render(<App />);
+
+    expect(await screen.findByLabelText("Document title")).toHaveValue("Architecture Overview");
+
+    await act(async () => {
+      fireEvent.change(screen.getByTestId("assistant-composer-input"), {
+        target: { value: "What changed here?" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    });
+
+    expect(sendAssistantMessage).toHaveBeenCalledWith({
+      noteRelativePath: "docs/Architecture.md",
+      content: "What changed here?",
+      documentTitle: "Architecture Overview",
+      documentMarkdown: "Current body.\n",
+    });
+    expect(await screen.findByText("What changed here?")).toBeInTheDocument();
+    expect(screen.getByText("Thinking...")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Summarize this note" })).toBeDisabled();
+
+    await act(async () => {
+      onAssistantEventListener?.({
+        workspacePath: "/workspaces/alpha",
+        noteRelativePath: "docs/Architecture.md",
+        thread: createAssistantThread("docs/Architecture.md", {
+          messages: [
+            {
+              id: "user-1",
+              role: "user",
+              content: "What changed here?",
+              createdAt: "2026-03-22T00:00:00.000Z",
+            },
+            {
+              id: "assistant-1",
+              role: "assistant",
+              content: "Here is the streamed answer.",
+              createdAt: "2026-03-22T00:00:00.000Z",
+            },
+          ],
+          status: "idle",
+        }),
+      });
+    });
+
+    expect(screen.getByText("Here is the streamed answer.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "README" }));
+    });
+    expect(await screen.findByLabelText("Document title")).toHaveValue("README");
+    expect(getAssistantThread).toHaveBeenLastCalledWith("README.md");
+    expect(screen.queryByText("Here is the streamed answer.")).not.toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Summarize this note" }));
+    });
+    expect(sendAssistantMessage).toHaveBeenLastCalledWith({
+      noteRelativePath: "README.md",
+      content: "Summarize this note",
+      documentTitle: "README",
+      documentMarkdown: "Readme body.\n",
+    });
+  });
 });

--- a/desktop/src/renderer/test/App.test.tsx
+++ b/desktop/src/renderer/test/App.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import type {
   AssistantEvent,
   AssistantThread,
+  AssistantThreadSummary,
   DocumentChangedEvent,
   MohioApi,
   WorkspaceSummary,
@@ -9,14 +10,32 @@ import type {
 import App from "@renderer/App";
 
 function createAssistantThread(
-  noteRelativePath: string,
+  threadId: string,
   overrides: Partial<AssistantThread> = {},
 ): AssistantThread {
   return {
-    noteRelativePath,
+    id: threadId,
+    workspacePath: "/workspaces/alpha",
+    title: "New Chat",
+    preview: "",
     messages: [],
     status: "idle",
     errorMessage: null,
+    ...overrides,
+  };
+}
+
+function createAssistantThreadSummary(
+  threadId: string,
+  overrides: Partial<AssistantThreadSummary> = {},
+): AssistantThreadSummary {
+  return {
+    id: threadId,
+    title: "New Chat",
+    preview: "",
+    createdAt: "2026-03-23T00:00:00.000Z",
+    updatedAt: "2026-03-23T00:00:00.000Z",
+    status: "idle",
     ...overrides,
   };
 }
@@ -37,8 +56,10 @@ function createMohioMock(overrides: Partial<MohioApi> = {}): MohioApi {
       throw new Error("No document");
     },
     watchDocument: async () => undefined,
-    getAssistantThread: async (noteRelativePath) => createAssistantThread(noteRelativePath),
-    sendAssistantMessage: async (input) => createAssistantThread(input.noteRelativePath, {
+    listAssistantThreads: async () => [],
+    createAssistantThread: async () => createAssistantThread("thread-1"),
+    getAssistantThread: async (threadId) => createAssistantThread(threadId),
+    sendAssistantMessage: async (input) => createAssistantThread(input.threadId, {
       messages: [
         {
           id: "user-1",
@@ -50,6 +71,8 @@ function createMohioMock(overrides: Partial<MohioApi> = {}): MohioApi {
       status: "running",
     }),
     cancelAssistantRun: async () => undefined,
+    renameAssistantThread: async () => undefined,
+    deleteAssistantThread: async () => undefined,
     onDocumentChanged: () => () => undefined,
     onWorkspaceChanged: () => () => undefined,
     onAssistantEvent: () => () => undefined,
@@ -68,22 +91,24 @@ describe("App", () => {
     expect(topBar).toBeInTheDocument();
     expect(screen.getByTestId("workspace-sidebar")).toBeInTheDocument();
     expect(screen.getByTestId("assistant-sidebar")).toBeInTheDocument();
-    expect(within(topBar).getByRole("button", { name: "Select workspace" })).toHaveTextContent("Open a workspace");
+    expect(within(topBar).getByRole("button", { name: "Select workspace" })).toHaveTextContent("Open Workspace");
     expect(within(topBar).getByLabelText("Search workspace")).toBeInTheDocument();
     expect(await screen.findByTestId("document-state")).toHaveTextContent("Choose a folder to open your Mohio workspace.");
     expect(screen.getByText("No workspace is open.")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Choose folder" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Open Workspace" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "New Note" })).toBeDisabled();
     expect(screen.queryByRole("button", { name: "Heading 1" })).not.toBeInTheDocument();
     expect(screen.getByText("Assistant")).toBeInTheDocument();
-    expect(screen.getByText("Open a workspace note to chat with Codex")).toBeInTheDocument();
+    expect(screen.getByText("Open a workspace to chat with the assistant")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "New Chat" })).toBeDisabled();
     expect(screen.queryByText("Codex chat")).not.toBeInTheDocument();
     expect(
       screen.queryByText("Open a workspace to start chatting with Codex inside Mohio."),
     ).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Summarize this note" })).toBeDisabled();
-    expect(screen.getByLabelText("Assistant composer")).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+    expect(screen.queryByRole("button", { name: "Summarize this note" })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Assistant composer")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Send" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Cancel" })).not.toBeInTheDocument();
   });
 
   it("renders the workspace tree, switches workspaces, and loads note assistant state", async () => {
@@ -152,9 +177,31 @@ describe("App", () => {
         displayTitle: "Team Handbook",
         markdown: "Beta body.\n",
       });
-    const getAssistantThread = vi.fn().mockImplementation(async (noteRelativePath: string) => {
-      if (noteRelativePath === "Team Handbook.md") {
-        return createAssistantThread("Team Handbook.md", {
+    const listAssistantThreads = vi.fn()
+      .mockResolvedValueOnce([
+        createAssistantThreadSummary("thread-alpha", {
+          preview: "Architecture follow-up",
+          title: "Architecture follow-up",
+        }),
+      ])
+      .mockResolvedValueOnce([
+        createAssistantThreadSummary("thread-beta", {
+          preview: "Beta workspace summary",
+          title: "Beta workspace summary",
+        }),
+      ])
+      .mockResolvedValue([
+        createAssistantThreadSummary("thread-beta", {
+          preview: "Beta workspace summary",
+          title: "Beta workspace summary",
+        }),
+      ]);
+    const getAssistantThread = vi.fn().mockImplementation(async (threadId: string) => {
+      if (threadId === "thread-beta") {
+        return createAssistantThread("thread-beta", {
+          title: "Beta workspace summary",
+          preview: "Beta workspace summary",
+          workspacePath: "/workspaces/beta",
           messages: [
             {
               id: "assistant-1",
@@ -166,13 +213,17 @@ describe("App", () => {
         });
       }
 
-      return createAssistantThread(noteRelativePath);
+      return createAssistantThread(threadId, {
+        title: "Architecture follow-up",
+        preview: "Architecture follow-up",
+      });
     });
 
     window.mohio = createMohioMock({
       getCurrentWorkspace,
       openWorkspace,
       readDocument,
+      listAssistantThreads,
       getAssistantThread,
       onDocumentChanged: (listener) => {
         onDocumentChangedListener = listener;
@@ -197,8 +248,11 @@ describe("App", () => {
     expect(docsFolderToggle).toHaveAttribute("aria-expanded", "true");
     expect(screen.getByRole("button", { name: "Architecture Overview" })).toHaveAttribute("aria-current", "page");
     expect(await screen.findByLabelText("Document title")).toHaveValue("Architecture Overview");
+    expect(screen.getByRole("button", { name: "New Note" })).toBeDisabled();
     expect(screen.queryByText("alpha · docs/Architecture.md")).not.toBeInTheDocument();
-    expect(getAssistantThread).toHaveBeenCalledWith("docs/Architecture.md");
+    expect(listAssistantThreads).toHaveBeenCalledTimes(1);
+    expect(getAssistantThread).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: /Architecture follow-up/ })).toBeInTheDocument();
 
     fireEvent.click(docsFolderToggle);
     expect(docsFolderToggle).toHaveAttribute("aria-expanded", "false");
@@ -214,7 +268,9 @@ describe("App", () => {
     expect(screen.getByRole("button", { name: "Team Handbook" })).toHaveAttribute("aria-current", "page");
     expect(await screen.findByLabelText("Document title")).toHaveValue("Team Handbook");
     expect(screen.queryByText("beta · Team Handbook.md")).not.toBeInTheDocument();
-    expect(screen.getByText("Beta workspace summary.")).toBeInTheDocument();
+    expect(listAssistantThreads).toHaveBeenCalledTimes(2);
+    expect(getAssistantThread).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: /Beta workspace summary/ })).toBeInTheDocument();
 
     expect(onDocumentChangedListener).not.toBeNull();
     expect(onAssistantEventListener).not.toBeNull();
@@ -248,10 +304,20 @@ describe("App", () => {
     expect(await screen.findByLabelText("Document title")).toHaveValue("Team Handbook Updated");
 
     await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /Beta workspace summary/ }));
+    });
+
+    expect(getAssistantThread).toHaveBeenCalledWith("thread-beta");
+    expect(await screen.findByText("Beta workspace summary.")).toBeInTheDocument();
+
+    await act(async () => {
       onAssistantEventListener?.({
+        type: "thread",
         workspacePath: "/workspaces/beta",
-        noteRelativePath: "Team Handbook.md",
-        thread: createAssistantThread("Team Handbook.md", {
+        thread: createAssistantThread("thread-beta", {
+          title: "Beta workspace summary",
+          preview: "Beta workspace summary",
+          workspacePath: "/workspaces/beta",
           messages: [
             {
               id: "assistant-2",
@@ -377,10 +443,30 @@ describe("App", () => {
     }
   }, 10000);
 
-  it("sends assistant messages, streams updates, and keeps note conversations separate", async () => {
+  it("uses a list-first assistant flow with Codex chat actions", async () => {
     let onAssistantEventListener: ((event: AssistantEvent) => void) | null = null;
+    const renameAssistantThread = vi.fn().mockResolvedValue(undefined);
+    const deleteAssistantThread = vi.fn().mockResolvedValue(undefined);
+    const createAssistantThreadMock = vi.fn().mockResolvedValue(
+      createAssistantThread("thread-new", {
+        title: "New Chat",
+        preview: "",
+      }),
+    );
+    const listAssistantThreads = vi.fn().mockResolvedValue([
+      createAssistantThreadSummary("thread-architecture", {
+        preview: "Architecture follow-up",
+        title: "Architecture follow-up",
+      }),
+      createAssistantThreadSummary("thread-readme", {
+        preview: "README research",
+        title: "README research",
+      }),
+    ]);
     const sendAssistantMessage = vi.fn().mockImplementation(async (input) =>
-      createAssistantThread(input.noteRelativePath, {
+      createAssistantThread(input.threadId, {
+        preview: "Architecture follow-up",
+        title: input.threadId === "thread-new" ? "New Chat" : "Architecture follow-up",
         messages: [
           {
             id: "user-1",
@@ -398,9 +484,41 @@ describe("App", () => {
         status: "running",
       }),
     );
-    const getAssistantThread = vi.fn().mockImplementation(async (noteRelativePath) =>
-      createAssistantThread(noteRelativePath),
-    );
+    const getAssistantThread = vi.fn().mockImplementation(async (threadId) => {
+      if (threadId === "thread-readme") {
+        return createAssistantThread("thread-readme", {
+          preview: "README research",
+          title: "README research",
+          messages: [
+            {
+              id: "assistant-2",
+              role: "assistant",
+              content: "README history context.",
+              createdAt: "2026-03-22T00:00:00.000Z",
+            },
+          ],
+        });
+      }
+
+      if (threadId === "thread-new") {
+        return createAssistantThread("thread-new", {
+          title: "New Chat",
+        });
+      }
+
+      return createAssistantThread("thread-architecture", {
+        preview: "Architecture follow-up",
+        title: "Architecture follow-up",
+        messages: [
+          {
+            id: "assistant-architecture",
+            role: "assistant",
+            content: "Architecture thread context.",
+            createdAt: "2026-03-22T00:00:00.000Z",
+          },
+        ],
+      });
+    });
 
     window.mohio = createMohioMock({
       getCurrentWorkspace: async () => ({
@@ -424,22 +542,19 @@ describe("App", () => {
           },
         ],
       }),
-      readDocument: vi.fn()
-        .mockResolvedValueOnce({
-          relativePath: "docs/Architecture.md",
-          fileName: "Architecture.md",
-          displayTitle: "Architecture Overview",
-          markdown: "Current body.\n",
-        })
-        .mockResolvedValueOnce({
-          relativePath: "README.md",
-          fileName: "README.md",
-          displayTitle: "README",
-          markdown: "Readme body.\n",
-        }),
+      readDocument: vi.fn().mockResolvedValue({
+        relativePath: "docs/Architecture.md",
+        fileName: "Architecture.md",
+        displayTitle: "Architecture Overview",
+        markdown: "Current body.\n",
+      }),
+      listAssistantThreads,
+      createAssistantThread: createAssistantThreadMock,
       getAssistantThread,
       sendAssistantMessage,
       cancelAssistantRun: vi.fn().mockResolvedValue(undefined),
+      renameAssistantThread,
+      deleteAssistantThread,
       onAssistantEvent: (listener) => {
         onAssistantEventListener = listener;
         return () => {
@@ -448,70 +563,293 @@ describe("App", () => {
       },
     });
 
+    const promptSpy = vi.spyOn(window, "prompt").mockReturnValue("Renamed README chat");
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    try {
+      render(<App />);
+
+      expect(await screen.findByLabelText("Document title")).toHaveValue("Architecture Overview");
+      expect(getAssistantThread).not.toHaveBeenCalled();
+      expect(screen.getByRole("button", { name: "New Chat" })).toBeEnabled();
+      expect(screen.getByRole("button", { name: /Architecture follow-up/ })).toBeInTheDocument();
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: /Architecture follow-up/ }));
+      });
+
+      expect(getAssistantThread).toHaveBeenCalledWith("thread-architecture");
+      expect(await screen.findByText("Architecture thread context.")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Back to chats" })).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "Architecture follow-up" })).toBeInTheDocument();
+
+      await act(async () => {
+        fireEvent.change(screen.getByTestId("assistant-composer-input"), {
+          target: { value: "What changed here?" },
+        });
+        fireEvent.click(screen.getByRole("button", { name: "Send" }));
+      });
+
+      expect(sendAssistantMessage).toHaveBeenCalledWith({
+        threadId: "thread-architecture",
+        noteRelativePath: "docs/Architecture.md",
+        content: "What changed here?",
+        documentTitle: "Architecture Overview",
+        documentMarkdown: "Current body.\n",
+      });
+      expect(await screen.findByText("What changed here?")).toBeInTheDocument();
+      expect(screen.getByText("Thinking...")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Cancel" })).toBeEnabled();
+      expect(screen.getByRole("button", { name: "Summarize this note" })).toBeDisabled();
+
+      await act(async () => {
+        onAssistantEventListener?.({
+          type: "thread",
+          workspacePath: "/workspaces/alpha",
+          thread: createAssistantThread("thread-architecture", {
+            preview: "Architecture follow-up",
+            title: "Architecture follow-up",
+            messages: [
+              {
+                id: "user-1",
+                role: "user",
+                content: "What changed here?",
+                createdAt: "2026-03-22T00:00:00.000Z",
+              },
+              {
+                id: "assistant-1",
+                role: "assistant",
+                content: "Here is the streamed answer.",
+                createdAt: "2026-03-22T00:00:00.000Z",
+              },
+            ],
+            status: "running",
+          }),
+        });
+      });
+
+      expect(screen.getByText("Here is the streamed answer.")).toBeInTheDocument();
+      expect(screen.queryByText("Thinking...")).not.toBeInTheDocument();
+
+      await act(async () => {
+        await new Promise((resolve) => {
+          setTimeout(resolve, 1000);
+        });
+      });
+
+      expect(screen.getByText("Here is the streamed answer.")).toBeInTheDocument();
+      expect(screen.getByText("Thinking...")).toBeInTheDocument();
+
+      await act(async () => {
+        onAssistantEventListener?.({
+          type: "thread",
+          workspacePath: "/workspaces/alpha",
+          thread: createAssistantThread("thread-architecture", {
+            preview: "Architecture follow-up",
+            title: "Architecture follow-up",
+            messages: [
+              {
+                id: "user-1",
+                role: "user",
+                content: "What changed here?",
+                createdAt: "2026-03-22T00:00:00.000Z",
+              },
+              {
+                id: "assistant-1",
+                role: "assistant",
+                content: "Here is the streamed answer. It stays visible.",
+                createdAt: "2026-03-22T00:00:00.000Z",
+              },
+            ],
+            status: "idle",
+          }),
+        });
+      });
+
+      expect(screen.getByText("Here is the streamed answer. It stays visible.")).toBeInTheDocument();
+      expect(screen.queryByText("Thinking...")).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Back to chats" }));
+      });
+
+      expect(screen.queryByText("Here is the streamed answer. It stays visible.")).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /README research/ })).toBeInTheDocument();
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: /README research/ }));
+      });
+
+      expect(getAssistantThread).toHaveBeenLastCalledWith("thread-readme");
+      expect(await screen.findByText("README history context.")).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: "Chat options" }));
+      expect(screen.getByRole("button", { name: "Chat options" })).toHaveAttribute("aria-expanded", "true");
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("menuitem", { name: "Rename Chat" }));
+      });
+
+      expect(renameAssistantThread).toHaveBeenCalledWith({
+        threadId: "thread-readme",
+        title: "Renamed README chat",
+      });
+      expect(await screen.findByRole("heading", { name: "Renamed README chat" })).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: "Chat options" }));
+      expect(screen.getByRole("button", { name: "Chat options" })).toHaveAttribute("aria-expanded", "true");
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("menuitem", { name: "New Chat" }));
+      });
+
+      expect(createAssistantThreadMock).toHaveBeenCalledTimes(1);
+      expect(await screen.findByRole("heading", { name: "New Chat" })).toBeInTheDocument();
+
+      await act(async () => {
+        onAssistantEventListener?.({
+          type: "thread-list",
+          workspacePath: "/workspaces/alpha",
+          threads: [
+            createAssistantThreadSummary("thread-architecture", {
+              preview: "Architecture follow-up",
+              title: "Architecture follow-up",
+            }),
+            createAssistantThreadSummary("thread-readme", {
+              preview: "README research",
+              title: "README research",
+            }),
+          ],
+        });
+      });
+
+      expect(screen.getByRole("heading", { name: "New Chat" })).toBeInTheDocument();
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Summarize this note" }));
+      });
+
+      expect(sendAssistantMessage).toHaveBeenLastCalledWith({
+        threadId: "thread-new",
+        noteRelativePath: "docs/Architecture.md",
+        content: "Summarize this note",
+        documentTitle: "Architecture Overview",
+        documentMarkdown: "Current body.\n",
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: "Chat options" }));
+      expect(screen.getByRole("button", { name: "Chat options" })).toHaveAttribute("aria-expanded", "true");
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("menuitem", { name: "Delete Chat" }));
+      });
+
+      expect(deleteAssistantThread).toHaveBeenCalledWith("thread-new");
+      expect(screen.getByRole("button", { name: /Architecture follow-up/ })).toBeInTheDocument();
+      expect(screen.queryByRole("heading", { name: "New Chat" })).not.toBeInTheDocument();
+    } finally {
+      promptSpy.mockRestore();
+      confirmSpy.mockRestore();
+    }
+  });
+
+  it("auto-starts a new chat when sending from the list footer", async () => {
+    const createAssistantThreadMock = vi.fn()
+      .mockResolvedValueOnce(createAssistantThread("thread-action", { title: "New Chat" }))
+      .mockResolvedValueOnce(createAssistantThread("thread-compose", { title: "New Chat" }));
+    const sendAssistantMessage = vi.fn().mockImplementation(async (input) =>
+      createAssistantThread(input.threadId, {
+        title: "New Chat",
+        preview: input.content,
+        status: "running",
+        messages: [
+          {
+            id: "user-1",
+            role: "user",
+            content: input.content,
+            createdAt: "2026-03-22T00:00:00.000Z",
+          },
+          {
+            id: "assistant-1",
+            role: "assistant",
+            content: "",
+            createdAt: "2026-03-22T00:00:00.000Z",
+          },
+        ],
+      }),
+    );
+
+    window.mohio = createMohioMock({
+      getCurrentWorkspace: async () => ({
+        name: "alpha",
+        path: "/workspaces/alpha",
+        documentCount: 1,
+        documents: [
+          {
+            id: "docs/Architecture.md",
+            kind: "document",
+            name: "Architecture.md",
+            relativePath: "docs/Architecture.md",
+            displayTitle: "Architecture Overview",
+          },
+        ],
+      }),
+      readDocument: vi.fn().mockResolvedValue({
+        relativePath: "docs/Architecture.md",
+        fileName: "Architecture.md",
+        displayTitle: "Architecture Overview",
+        markdown: "Current body.\n",
+      }),
+      listAssistantThreads: vi.fn().mockResolvedValue([
+        createAssistantThreadSummary("thread-history", {
+          title: "History chat",
+          preview: "Earlier thread",
+        }),
+      ]),
+      createAssistantThread: createAssistantThreadMock,
+      sendAssistantMessage,
+    });
+
     render(<App />);
 
     expect(await screen.findByLabelText("Document title")).toHaveValue("Architecture Overview");
-
-    await act(async () => {
-      fireEvent.change(screen.getByTestId("assistant-composer-input"), {
-        target: { value: "What changed here?" },
-      });
-      fireEvent.click(screen.getByRole("button", { name: "Send" }));
-    });
-
-    expect(sendAssistantMessage).toHaveBeenCalledWith({
-      noteRelativePath: "docs/Architecture.md",
-      content: "What changed here?",
-      documentTitle: "Architecture Overview",
-      documentMarkdown: "Current body.\n",
-    });
-    expect(await screen.findByText("What changed here?")).toBeInTheDocument();
-    expect(screen.getByText("Thinking...")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Cancel" })).toBeEnabled();
-    expect(screen.getByRole("button", { name: "Summarize this note" })).toBeDisabled();
-
-    await act(async () => {
-      onAssistantEventListener?.({
-        workspacePath: "/workspaces/alpha",
-        noteRelativePath: "docs/Architecture.md",
-        thread: createAssistantThread("docs/Architecture.md", {
-          messages: [
-            {
-              id: "user-1",
-              role: "user",
-              content: "What changed here?",
-              createdAt: "2026-03-22T00:00:00.000Z",
-            },
-            {
-              id: "assistant-1",
-              role: "assistant",
-              content: "Here is the streamed answer.",
-              createdAt: "2026-03-22T00:00:00.000Z",
-            },
-          ],
-          status: "idle",
-        }),
-      });
-    });
-
-    expect(screen.getByText("Here is the streamed answer.")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
-
-    await act(async () => {
-      fireEvent.click(screen.getByRole("button", { name: "README" }));
-    });
-    expect(await screen.findByLabelText("Document title")).toHaveValue("README");
-    expect(getAssistantThread).toHaveBeenLastCalledWith("README.md");
-    expect(screen.queryByText("Here is the streamed answer.")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Summarize this note" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
 
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: "Summarize this note" }));
     });
-    expect(sendAssistantMessage).toHaveBeenLastCalledWith({
-      noteRelativePath: "README.md",
+
+    expect(createAssistantThreadMock).toHaveBeenCalledTimes(1);
+    expect(sendAssistantMessage).toHaveBeenCalledWith({
+      threadId: "thread-action",
+      noteRelativePath: "docs/Architecture.md",
       content: "Summarize this note",
-      documentTitle: "README",
-      documentMarkdown: "Readme body.\n",
+      documentTitle: "Architecture Overview",
+      documentMarkdown: "Current body.\n",
     });
+    expect(await screen.findByRole("heading", { name: "New Chat" })).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Back to chats" }));
+    });
+
+    await act(async () => {
+      fireEvent.change(screen.getByTestId("assistant-composer-input"), {
+        target: { value: "Draft a short summary." },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    });
+
+    expect(createAssistantThreadMock).toHaveBeenCalledTimes(2);
+    expect(sendAssistantMessage).toHaveBeenLastCalledWith({
+      threadId: "thread-compose",
+      noteRelativePath: "docs/Architecture.md",
+      content: "Draft a short summary.",
+      documentTitle: "Architecture Overview",
+      documentMarkdown: "Current body.\n",
+    });
+    expect(await screen.findByRole("heading", { name: "New Chat" })).toBeInTheDocument();
   });
 });

--- a/desktop/src/shared/mohio-api.test.ts
+++ b/desktop/src/shared/mohio-api.test.ts
@@ -32,8 +32,29 @@ describe("createMohioApi", () => {
       savedAt: "2026-03-21T00:00:00.000Z",
     });
     const watchDocument = vi.fn().mockResolvedValue(undefined);
+    const getAssistantThread = vi.fn().mockResolvedValue({
+      noteRelativePath: "README.md",
+      messages: [],
+      status: "idle" as const,
+      errorMessage: null,
+    });
+    const sendAssistantMessage = vi.fn().mockResolvedValue({
+      noteRelativePath: "README.md",
+      messages: [
+        {
+          id: "message-1",
+          role: "user" as const,
+          content: "Summarize this note",
+          createdAt: "2026-03-21T00:00:00.000Z",
+        },
+      ],
+      status: "running" as const,
+      errorMessage: null,
+    });
+    const cancelAssistantRun = vi.fn().mockResolvedValue(undefined);
     const onDocumentChanged = vi.fn().mockReturnValue(() => undefined);
     const onWorkspaceChanged = vi.fn().mockReturnValue(() => undefined);
+    const onAssistantEvent = vi.fn().mockReturnValue(() => undefined);
 
     const api = createMohioApi({
       appInfo: {
@@ -46,8 +67,12 @@ describe("createMohioApi", () => {
       readDocument,
       saveDocument,
       watchDocument,
+      getAssistantThread,
+      sendAssistantMessage,
+      cancelAssistantRun,
       onDocumentChanged,
       onWorkspaceChanged,
+      onAssistantEvent,
     });
 
     expect(api.getAppInfo()).toEqual({
@@ -67,8 +92,34 @@ describe("createMohioApi", () => {
       savedAt: "2026-03-21T00:00:00.000Z",
     });
     await expect(api.watchDocument("README.md")).resolves.toBeUndefined();
+    await expect(api.getAssistantThread("README.md")).resolves.toEqual({
+      noteRelativePath: "README.md",
+      messages: [],
+      status: "idle",
+      errorMessage: null,
+    });
+    await expect(api.sendAssistantMessage({
+      noteRelativePath: "README.md",
+      content: "Summarize this note",
+      documentTitle: "README",
+      documentMarkdown: "Body",
+    })).resolves.toEqual({
+      noteRelativePath: "README.md",
+      messages: [
+        {
+          id: "message-1",
+          role: "user",
+          content: "Summarize this note",
+          createdAt: "2026-03-21T00:00:00.000Z",
+        },
+      ],
+      status: "running",
+      errorMessage: null,
+    });
+    await expect(api.cancelAssistantRun("README.md")).resolves.toBeUndefined();
     expect(api.onWorkspaceChanged(() => undefined)).toEqual(expect.any(Function));
     expect(api.onDocumentChanged(() => undefined)).toEqual(expect.any(Function));
+    expect(api.onAssistantEvent(() => undefined)).toEqual(expect.any(Function));
     expect(getCurrentWorkspace).toHaveBeenCalledTimes(1);
     expect(openWorkspace).toHaveBeenCalledTimes(1);
     expect(readDocument).toHaveBeenCalledWith("README.md");
@@ -78,7 +129,16 @@ describe("createMohioApi", () => {
       markdown: "Body",
     });
     expect(watchDocument).toHaveBeenCalledWith("README.md");
+    expect(getAssistantThread).toHaveBeenCalledWith("README.md");
+    expect(sendAssistantMessage).toHaveBeenCalledWith({
+      noteRelativePath: "README.md",
+      content: "Summarize this note",
+      documentTitle: "README",
+      documentMarkdown: "Body",
+    });
+    expect(cancelAssistantRun).toHaveBeenCalledWith("README.md");
     expect(onDocumentChanged).toHaveBeenCalledTimes(1);
     expect(onWorkspaceChanged).toHaveBeenCalledTimes(1);
+    expect(onAssistantEvent).toHaveBeenCalledTimes(1);
   });
 });

--- a/desktop/src/shared/mohio-api.test.ts
+++ b/desktop/src/shared/mohio-api.test.ts
@@ -32,14 +32,39 @@ describe("createMohioApi", () => {
       savedAt: "2026-03-21T00:00:00.000Z",
     });
     const watchDocument = vi.fn().mockResolvedValue(undefined);
+    const listAssistantThreads = vi.fn().mockResolvedValue([
+      {
+        id: "thread-1",
+        title: "README summary",
+        preview: "README summary",
+        createdAt: "2026-03-21T00:00:00.000Z",
+        updatedAt: "2026-03-21T00:00:00.000Z",
+        status: "idle" as const,
+      },
+    ]);
+    const createAssistantThread = vi.fn().mockResolvedValue({
+      id: "thread-1",
+      workspacePath: "/workspace/mohio",
+      title: "README summary",
+      preview: "README summary",
+      messages: [],
+      status: "idle" as const,
+      errorMessage: null,
+    });
     const getAssistantThread = vi.fn().mockResolvedValue({
-      noteRelativePath: "README.md",
+      id: "thread-1",
+      workspacePath: "/workspace/mohio",
+      title: "README summary",
+      preview: "README summary",
       messages: [],
       status: "idle" as const,
       errorMessage: null,
     });
     const sendAssistantMessage = vi.fn().mockResolvedValue({
-      noteRelativePath: "README.md",
+      id: "thread-1",
+      workspacePath: "/workspace/mohio",
+      title: "README summary",
+      preview: "README summary",
       messages: [
         {
           id: "message-1",
@@ -52,6 +77,8 @@ describe("createMohioApi", () => {
       errorMessage: null,
     });
     const cancelAssistantRun = vi.fn().mockResolvedValue(undefined);
+    const renameAssistantThread = vi.fn().mockResolvedValue(undefined);
+    const deleteAssistantThread = vi.fn().mockResolvedValue(undefined);
     const onDocumentChanged = vi.fn().mockReturnValue(() => undefined);
     const onWorkspaceChanged = vi.fn().mockReturnValue(() => undefined);
     const onAssistantEvent = vi.fn().mockReturnValue(() => undefined);
@@ -67,9 +94,13 @@ describe("createMohioApi", () => {
       readDocument,
       saveDocument,
       watchDocument,
+      listAssistantThreads,
+      createAssistantThread,
       getAssistantThread,
       sendAssistantMessage,
       cancelAssistantRun,
+      renameAssistantThread,
+      deleteAssistantThread,
       onDocumentChanged,
       onWorkspaceChanged,
       onAssistantEvent,
@@ -92,19 +123,45 @@ describe("createMohioApi", () => {
       savedAt: "2026-03-21T00:00:00.000Z",
     });
     await expect(api.watchDocument("README.md")).resolves.toBeUndefined();
-    await expect(api.getAssistantThread("README.md")).resolves.toEqual({
-      noteRelativePath: "README.md",
+    await expect(api.listAssistantThreads()).resolves.toEqual([
+      {
+        id: "thread-1",
+        title: "README summary",
+        preview: "README summary",
+        createdAt: "2026-03-21T00:00:00.000Z",
+        updatedAt: "2026-03-21T00:00:00.000Z",
+        status: "idle",
+      },
+    ]);
+    await expect(api.createAssistantThread()).resolves.toEqual({
+      id: "thread-1",
+      workspacePath: "/workspace/mohio",
+      title: "README summary",
+      preview: "README summary",
+      messages: [],
+      status: "idle",
+      errorMessage: null,
+    });
+    await expect(api.getAssistantThread("thread-1")).resolves.toEqual({
+      id: "thread-1",
+      workspacePath: "/workspace/mohio",
+      title: "README summary",
+      preview: "README summary",
       messages: [],
       status: "idle",
       errorMessage: null,
     });
     await expect(api.sendAssistantMessage({
+      threadId: "thread-1",
       noteRelativePath: "README.md",
       content: "Summarize this note",
       documentTitle: "README",
       documentMarkdown: "Body",
     })).resolves.toEqual({
-      noteRelativePath: "README.md",
+      id: "thread-1",
+      workspacePath: "/workspace/mohio",
+      title: "README summary",
+      preview: "README summary",
       messages: [
         {
           id: "message-1",
@@ -116,7 +173,12 @@ describe("createMohioApi", () => {
       status: "running",
       errorMessage: null,
     });
-    await expect(api.cancelAssistantRun("README.md")).resolves.toBeUndefined();
+    await expect(api.cancelAssistantRun("thread-1")).resolves.toBeUndefined();
+    await expect(api.renameAssistantThread({
+      threadId: "thread-1",
+      title: "Renamed chat",
+    })).resolves.toBeUndefined();
+    await expect(api.deleteAssistantThread("thread-1")).resolves.toBeUndefined();
     expect(api.onWorkspaceChanged(() => undefined)).toEqual(expect.any(Function));
     expect(api.onDocumentChanged(() => undefined)).toEqual(expect.any(Function));
     expect(api.onAssistantEvent(() => undefined)).toEqual(expect.any(Function));
@@ -129,14 +191,22 @@ describe("createMohioApi", () => {
       markdown: "Body",
     });
     expect(watchDocument).toHaveBeenCalledWith("README.md");
-    expect(getAssistantThread).toHaveBeenCalledWith("README.md");
+    expect(listAssistantThreads).toHaveBeenCalledTimes(1);
+    expect(createAssistantThread).toHaveBeenCalledTimes(1);
+    expect(getAssistantThread).toHaveBeenCalledWith("thread-1");
     expect(sendAssistantMessage).toHaveBeenCalledWith({
+      threadId: "thread-1",
       noteRelativePath: "README.md",
       content: "Summarize this note",
       documentTitle: "README",
       documentMarkdown: "Body",
     });
-    expect(cancelAssistantRun).toHaveBeenCalledWith("README.md");
+    expect(cancelAssistantRun).toHaveBeenCalledWith("thread-1");
+    expect(renameAssistantThread).toHaveBeenCalledWith({
+      threadId: "thread-1",
+      title: "Renamed chat",
+    });
+    expect(deleteAssistantThread).toHaveBeenCalledWith("thread-1");
     expect(onDocumentChanged).toHaveBeenCalledTimes(1);
     expect(onWorkspaceChanged).toHaveBeenCalledTimes(1);
     expect(onAssistantEvent).toHaveBeenCalledTimes(1);

--- a/desktop/src/shared/mohio-api.ts
+++ b/desktop/src/shared/mohio-api.ts
@@ -1,9 +1,11 @@
 import type {
   AssistantEvent,
   AssistantThread,
+  AssistantThreadSummary,
   AppInfo,
   DocumentChangedEvent,
   MohioApi,
+  RenameAssistantThreadInput,
   SendAssistantMessageInput,
   SaveDocumentInput,
   SaveDocumentResult,
@@ -17,9 +19,13 @@ export const MOHIO_CHANNELS = {
   readDocument: "mohio:document:read",
   saveDocument: "mohio:document:save",
   watchDocument: "mohio:document:watch",
+  listAssistantThreads: "mohio:assistant:list-threads",
+  createAssistantThread: "mohio:assistant:create-thread",
   getAssistantThread: "mohio:assistant:get-thread",
   sendAssistantMessage: "mohio:assistant:send-message",
   cancelAssistantRun: "mohio:assistant:cancel-run",
+  renameAssistantThread: "mohio:assistant:rename-thread",
+  deleteAssistantThread: "mohio:assistant:delete-thread",
   documentChanged: "mohio:document:changed",
   workspaceChanged: "mohio:workspace:changed",
   assistantEvent: "mohio:assistant:event",
@@ -32,9 +38,13 @@ interface CreateMohioApiOptions {
   readDocument: (relativePath: string) => Promise<WorkspaceDocument>;
   saveDocument: (input: SaveDocumentInput) => Promise<SaveDocumentResult>;
   watchDocument: (relativePath: string | null) => Promise<void>;
-  getAssistantThread: (noteRelativePath: string) => Promise<AssistantThread>;
+  listAssistantThreads: () => Promise<AssistantThreadSummary[]>;
+  createAssistantThread: () => Promise<AssistantThread>;
+  getAssistantThread: (threadId: string) => Promise<AssistantThread>;
   sendAssistantMessage: (input: SendAssistantMessageInput) => Promise<AssistantThread>;
-  cancelAssistantRun: (noteRelativePath: string) => Promise<void>;
+  cancelAssistantRun: (threadId: string) => Promise<void>;
+  renameAssistantThread: (input: RenameAssistantThreadInput) => Promise<void>;
+  deleteAssistantThread: (threadId: string) => Promise<void>;
   onDocumentChanged: (
     listener: (event: DocumentChangedEvent) => void,
   ) => () => void;
@@ -53,9 +63,13 @@ export function createMohioApi({
   readDocument,
   saveDocument,
   watchDocument,
+  listAssistantThreads,
+  createAssistantThread,
   getAssistantThread,
   sendAssistantMessage,
   cancelAssistantRun,
+  renameAssistantThread,
+  deleteAssistantThread,
   onDocumentChanged,
   onWorkspaceChanged,
   onAssistantEvent,
@@ -67,9 +81,13 @@ export function createMohioApi({
     readDocument,
     saveDocument,
     watchDocument,
+    listAssistantThreads,
+    createAssistantThread,
     getAssistantThread,
     sendAssistantMessage,
     cancelAssistantRun,
+    renameAssistantThread,
+    deleteAssistantThread,
     onDocumentChanged,
     onWorkspaceChanged,
     onAssistantEvent,

--- a/desktop/src/shared/mohio-api.ts
+++ b/desktop/src/shared/mohio-api.ts
@@ -1,7 +1,10 @@
 import type {
+  AssistantEvent,
+  AssistantThread,
   AppInfo,
   DocumentChangedEvent,
   MohioApi,
+  SendAssistantMessageInput,
   SaveDocumentInput,
   SaveDocumentResult,
   WorkspaceDocument,
@@ -14,8 +17,12 @@ export const MOHIO_CHANNELS = {
   readDocument: "mohio:document:read",
   saveDocument: "mohio:document:save",
   watchDocument: "mohio:document:watch",
+  getAssistantThread: "mohio:assistant:get-thread",
+  sendAssistantMessage: "mohio:assistant:send-message",
+  cancelAssistantRun: "mohio:assistant:cancel-run",
   documentChanged: "mohio:document:changed",
   workspaceChanged: "mohio:workspace:changed",
+  assistantEvent: "mohio:assistant:event",
 } as const;
 
 interface CreateMohioApiOptions {
@@ -25,11 +32,17 @@ interface CreateMohioApiOptions {
   readDocument: (relativePath: string) => Promise<WorkspaceDocument>;
   saveDocument: (input: SaveDocumentInput) => Promise<SaveDocumentResult>;
   watchDocument: (relativePath: string | null) => Promise<void>;
+  getAssistantThread: (noteRelativePath: string) => Promise<AssistantThread>;
+  sendAssistantMessage: (input: SendAssistantMessageInput) => Promise<AssistantThread>;
+  cancelAssistantRun: (noteRelativePath: string) => Promise<void>;
   onDocumentChanged: (
     listener: (event: DocumentChangedEvent) => void,
   ) => () => void;
   onWorkspaceChanged: (
     listener: (workspace: WorkspaceSummary | null) => void,
+  ) => () => void;
+  onAssistantEvent: (
+    listener: (event: AssistantEvent) => void,
   ) => () => void;
 }
 
@@ -40,8 +53,12 @@ export function createMohioApi({
   readDocument,
   saveDocument,
   watchDocument,
+  getAssistantThread,
+  sendAssistantMessage,
+  cancelAssistantRun,
   onDocumentChanged,
   onWorkspaceChanged,
+  onAssistantEvent,
 }: CreateMohioApiOptions): MohioApi {
   return {
     getAppInfo: () => appInfo,
@@ -50,7 +67,11 @@ export function createMohioApi({
     readDocument,
     saveDocument,
     watchDocument,
+    getAssistantThread,
+    sendAssistantMessage,
+    cancelAssistantRun,
     onDocumentChanged,
     onWorkspaceChanged,
+    onAssistantEvent,
   };
 }

--- a/desktop/src/shared/mohio-types.ts
+++ b/desktop/src/shared/mohio-types.ts
@@ -67,24 +67,48 @@ export interface AssistantMessage {
   createdAt: string;
 }
 
+export interface AssistantThreadSummary {
+  id: string;
+  title: string;
+  preview: string;
+  createdAt: string;
+  updatedAt: string;
+  status: AssistantRunStatus;
+}
+
 export interface AssistantThread {
-  noteRelativePath: string;
+  id: string;
+  workspacePath: string;
+  title: string;
+  preview: string;
   messages: AssistantMessage[];
   status: AssistantRunStatus;
   errorMessage: string | null;
 }
 
-export interface AssistantEvent {
-  workspacePath: string;
-  noteRelativePath: string;
-  thread: AssistantThread;
-}
+export type AssistantEvent =
+  | {
+    type: "thread";
+    workspacePath: string;
+    thread: AssistantThread;
+  }
+  | {
+    type: "thread-list";
+    workspacePath: string;
+    threads: AssistantThreadSummary[];
+  };
 
 export interface SendAssistantMessageInput {
+  threadId: string;
   noteRelativePath: string;
   content: string;
   documentTitle: string;
   documentMarkdown: string;
+}
+
+export interface RenameAssistantThreadInput {
+  threadId: string;
+  title: string;
 }
 
 export interface MohioApi {
@@ -94,9 +118,13 @@ export interface MohioApi {
   readDocument: (relativePath: string) => Promise<WorkspaceDocument>;
   saveDocument: (input: SaveDocumentInput) => Promise<SaveDocumentResult>;
   watchDocument: (relativePath: string | null) => Promise<void>;
-  getAssistantThread: (noteRelativePath: string) => Promise<AssistantThread>;
+  listAssistantThreads: () => Promise<AssistantThreadSummary[]>;
+  createAssistantThread: () => Promise<AssistantThread>;
+  getAssistantThread: (threadId: string) => Promise<AssistantThread>;
   sendAssistantMessage: (input: SendAssistantMessageInput) => Promise<AssistantThread>;
-  cancelAssistantRun: (noteRelativePath: string) => Promise<void>;
+  cancelAssistantRun: (threadId: string) => Promise<void>;
+  renameAssistantThread: (input: RenameAssistantThreadInput) => Promise<void>;
+  deleteAssistantThread: (threadId: string) => Promise<void>;
   onDocumentChanged: (
     listener: (event: DocumentChangedEvent) => void,
   ) => () => void;

--- a/desktop/src/shared/mohio-types.ts
+++ b/desktop/src/shared/mohio-types.ts
@@ -57,6 +57,36 @@ export interface DocumentChangedEvent {
   workspace: WorkspaceSummary | null;
 }
 
+export type AssistantMessageRole = "assistant" | "user";
+export type AssistantRunStatus = "error" | "idle" | "running";
+
+export interface AssistantMessage {
+  id: string;
+  role: AssistantMessageRole;
+  content: string;
+  createdAt: string;
+}
+
+export interface AssistantThread {
+  noteRelativePath: string;
+  messages: AssistantMessage[];
+  status: AssistantRunStatus;
+  errorMessage: string | null;
+}
+
+export interface AssistantEvent {
+  workspacePath: string;
+  noteRelativePath: string;
+  thread: AssistantThread;
+}
+
+export interface SendAssistantMessageInput {
+  noteRelativePath: string;
+  content: string;
+  documentTitle: string;
+  documentMarkdown: string;
+}
+
 export interface MohioApi {
   getAppInfo: () => AppInfo;
   getCurrentWorkspace: () => Promise<WorkspaceSummary | null>;
@@ -64,10 +94,16 @@ export interface MohioApi {
   readDocument: (relativePath: string) => Promise<WorkspaceDocument>;
   saveDocument: (input: SaveDocumentInput) => Promise<SaveDocumentResult>;
   watchDocument: (relativePath: string | null) => Promise<void>;
+  getAssistantThread: (noteRelativePath: string) => Promise<AssistantThread>;
+  sendAssistantMessage: (input: SendAssistantMessageInput) => Promise<AssistantThread>;
+  cancelAssistantRun: (noteRelativePath: string) => Promise<void>;
   onDocumentChanged: (
     listener: (event: DocumentChangedEvent) => void,
   ) => () => void;
   onWorkspaceChanged: (
     listener: (workspace: WorkspaceSummary | null) => void,
+  ) => () => void;
+  onAssistantEvent: (
+    listener: (event: AssistantEvent) => void,
   ) => () => void;
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@ This document defines Mohio's current system boundary and data flow.
 - No backend service
 - No user account system
 - No external authentication flow
-- No live assistant integration yet
+- Codex-backed assistant integration through the locally installed `codex` CLI
 
 ## System Diagram
 
@@ -20,15 +20,17 @@ flowchart LR
   Preload --> Main["Electron Main Process"]
   Main --> Dialog["Native Open Dialog"]
   Main --> FS["Workspace File System\nMarkdown files"]
+  Main --> Codex["Installed Codex CLI\ncodex exec"]
   FS --> Main
+  Codex --> Main
   Main --> Renderer
 ```
 
 ## Runtime Areas
 
-- `Electron main`: window, menu, folder picker, filesystem access, file watching
+- `Electron main`: window, menu, folder picker, filesystem access, file watching, assistant process management
 - `Preload`: typed `window.mohio` bridge
-- `Renderer`: React UI for workspace tree and editor
+- `Renderer`: React UI for workspace tree, editor, and assistant transcript
 - `Workspace`: local folder with `.md`, `.markdown`, and `.mdx` files
 
 ## Data Flow
@@ -62,12 +64,22 @@ flowchart LR
 3. If the file changes on disk, main re-reads the workspace and document.
 4. Renderer updates the open editor unless that would overwrite unsaved local edits.
 
+### Assistant Conversation
+
+1. Renderer loads the current note thread through the preload API after note selection.
+2. Renderer sends the user message, current note title, and current note Markdown to main.
+3. Main starts `codex exec` in the active workspace root with read-only sandboxing and JSON output.
+4. Main includes workspace path, workspace name, note path, note body, and note-thread history in the prompt.
+5. Main streams JSONL assistant deltas back to renderer through assistant events.
+6. Renderer updates the right sidebar transcript while the run is active.
+
 ## Security and Trust Boundaries
 
 - The renderer runs with `contextIsolation: true`.
 - `nodeIntegration` is disabled in the renderer.
 - Native capabilities are only available through the preload API.
 - Document reads and writes are restricted to the active workspace root through path resolution checks.
+- Assistant runs execute from the workspace root, but Mohio starts Codex in read-only mode for this v1 integration.
 
 ## Third-Party Integrations
 
@@ -76,12 +88,14 @@ flowchart LR
 - `CodeMirror` for Markdown-source editing
 - `yaml` for frontmatter parsing and serialization
 - `lucide-react` for editor toolbar icons
+- `codex` CLI for assistant conversations
 
 ## Current Architectural Constraints
 
 - The app is single-window and desktop-only today.
 - Search UI exists as a placeholder input only; it is not wired to workspace querying.
-- The assistant sidebar is present as layout scaffolding only.
+- Assistant history is in-memory only and scoped to the current app session.
+- The assistant can chat about the workspace, but it cannot apply edits through Mohio yet.
 - Note creation, rename UI, delete UI, publish flow, checkpoints, and rendered preview are not implemented yet in the renderer.
 
 ## When To Update This Document

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@ This document defines Mohio's current system boundary and data flow.
 - No backend service
 - No user account system
 - No external authentication flow
-- Codex-backed assistant integration through the locally installed `codex` CLI
+- Codex-backed assistant integration through the locally installed `codex` CLI and Codex app-server session store
 
 ## System Diagram
 
@@ -20,7 +20,7 @@ flowchart LR
   Preload --> Main["Electron Main Process"]
   Main --> Dialog["Native Open Dialog"]
   Main --> FS["Workspace File System\nMarkdown files"]
-  Main --> Codex["Installed Codex CLI\ncodex exec"]
+  Main --> Codex["Installed Codex CLI\ncodex app-server"]
   FS --> Main
   Codex --> Main
   Main --> Renderer
@@ -28,9 +28,9 @@ flowchart LR
 
 ## Runtime Areas
 
-- `Electron main`: window, menu, folder picker, filesystem access, file watching, assistant process management
+- `Electron main`: window, menu, folder picker, filesystem access, file watching, Codex app-server client
 - `Preload`: typed `window.mohio` bridge
-- `Renderer`: React UI for workspace tree, editor, and assistant transcript
+- `Renderer`: React UI for workspace tree, editor, assistant history, and transcript
 - `Workspace`: local folder with `.md`, `.markdown`, and `.mdx` files
 
 ## Data Flow
@@ -66,12 +66,13 @@ flowchart LR
 
 ### Assistant Conversation
 
-1. Renderer loads the current note thread through the preload API after note selection.
-2. Renderer sends the user message, current note title, and current note Markdown to main.
-3. Main starts `codex exec` in the active workspace root with read-only sandboxing and JSON output.
-4. Main includes workspace path, workspace name, note path, note body, and note-thread history in the prompt.
-5. Main streams JSONL assistant deltas back to renderer through assistant events.
-6. Renderer updates the right sidebar transcript while the run is active.
+1. Renderer loads Codex chat history for the current workspace through the preload API.
+2. Renderer selects an existing Codex thread or creates a new one.
+3. Renderer sends the user message plus the current note title, note path, and current note Markdown to main.
+4. Main starts or resumes the Codex thread through `codex app-server`, always with the active workspace root as `cwd`.
+5. Main reuses Codex's existing config, auth state, and session storage instead of persisting assistant history itself.
+6. Main starts the turn, streams assistant deltas back to renderer through assistant events, and refreshes the workspace-filtered thread list when Codex thread state changes.
+7. Renderer updates the right sidebar transcript and history list while the run is active.
 
 ## Security and Trust Boundaries
 
@@ -80,6 +81,7 @@ flowchart LR
 - Native capabilities are only available through the preload API.
 - Document reads and writes are restricted to the active workspace root through path resolution checks.
 - Assistant runs execute from the workspace root, but Mohio starts Codex in read-only mode for this v1 integration.
+- Mohio reuses Codex's own session and auth storage rather than copying assistant history into a Mohio-owned store.
 
 ## Third-Party Integrations
 
@@ -87,14 +89,14 @@ flowchart LR
 - `React` for renderer composition
 - `CodeMirror` for Markdown-source editing
 - `yaml` for frontmatter parsing and serialization
-- `lucide-react` for editor toolbar icons
-- `codex` CLI for assistant conversations
+- `lucide-react` for shared shell, assistant, and editor toolbar icons
+- `codex` CLI and `codex app-server` for assistant conversations and session history
 
 ## Current Architectural Constraints
 
 - The app is single-window and desktop-only today.
 - Search UI exists as a placeholder input only; it is not wired to workspace querying.
-- Assistant history is in-memory only and scoped to the current app session.
+- Assistant history browsing is limited to Codex threads whose `cwd` exactly matches the open workspace path.
 - The assistant can chat about the workspace, but it cannot apply edits through Mohio yet.
 - Note creation, rename UI, delete UI, publish flow, checkpoints, and rendered preview are not implemented yet in the renderer.
 

--- a/docs/changelog/feature-20260322-ai-assistance.md
+++ b/docs/changelog/feature-20260322-ai-assistance.md
@@ -10,19 +10,34 @@ Mohio already had a three-panel desktop shell, but the right sidebar was only vi
 
 ## Change
 
-- Added a live assistant runtime in the Electron main process that starts the installed `codex` CLI with JSON event streaming.
-- Added assistant IPC methods and shared types for loading note threads, sending note-scoped messages, cancelling active runs, and receiving streamed assistant updates.
-- Implemented the right sidebar as a working Codex chat panel with transcript bubbles, quick actions, composer input, cancel behavior, and panel-local error handling.
-- Scoped conversations per note for the current app session while still running each Codex call from the active workspace root.
-- Passed the current note title, note body, workspace path, workspace name, and note-thread history into each assistant prompt.
-- Migrated in-memory assistant thread state when note saves rename a file through the title edit flow.
-- Added main-process and renderer coverage for Codex command startup, streamed updates, cancellation, rename migration, and assistant UI behavior.
+- Replaced the earlier `codex exec`-per-note runtime with a long-lived `codex app-server` client in the Electron main process.
+- Added assistant IPC methods and shared types for listing Codex chats, creating a new chat, loading a specific Codex thread, sending note-aware prompts into that thread, cancelling active runs, and receiving streamed assistant updates.
+- Implemented the right sidebar as a working Codex chat panel with a workspace-filtered history list, `New chat` action, parallel chat selection, transcript bubbles, quick actions, composer input, cancel behavior, and panel-local error handling.
+- Refined the assistant sidebar into a two-stage flow: a first screen for browsing Codex sessions, and a dedicated chat screen with back navigation plus per-thread `New chat`, rename, and delete actions.
+- Simplified the assistant empty-state copy to `Open a workspace to chat with the assistant`.
+- Normalized visible button labels to Title Case, including `Open Workspace`, `Open Folder`, `New Chat`, `Rename Chat`, `Delete Chat`, and the assistant quick actions.
+- Fixed two assistant chat regressions: new chats now stay open in the detail view before the first message, and existing Codex chats are resumed before Mohio starts a new turn on them.
+- Updated the chat presentation so back and new-chat controls use simple unframed icons, assistant replies render full-width without bubble chrome, and in-progress placeholder text uses a muted animated state.
+- Updated the `...` menu trigger to use the same unframed text-icon style as the other assistant header controls.
+- Kept assistant quick-action chips in sentence case as an intentional exception to the Title Case button rule.
+- Renamed the empty-workspace CTA from `Open Folder` to `Open Workspace`, removed the extra new-chat helper paragraph, switched the list-view action to a square-pen icon, and updated the chat back icon to a true left-arrow.
+- Replaced the remaining hand-drawn app-shell icons with `lucide-react` so the assistant panel and shell use the same icon system as the editor toolbar.
+- Simplified the assistant session list into a plain text title list without card borders, backgrounds, or preview text.
+- Swapped the assistant `New Chat` control to `message-square-plus` and added a matching link-style `New Note` square-pen control to the workspace sidebar header.
+- Refined streaming transcript behavior so `Thinking...` stays as a separate last-line status during quiet gaps in an active Codex run, disappears while fresh text is printing, and never replaces already rendered assistant content.
+- Moved the assistant footer to the bottom of the right sidebar in both list and thread views, and changed list-view quick actions/composer sends to auto-create a new chat before dispatching the first prompt.
+- Fixed a fresh-thread Codex error by retrying `turn/start` after `thread/resume` when Codex reports that no rollout exists yet for the new chat.
+- Hardened fresh-thread startup by allowing multiple bounded `turn/start` retries after `thread/resume` when Codex still reports no rollout, reducing first-message failures on new chats.
+- Reused Codex's existing config, auth state, and on-disk session history instead of maintaining a Mohio-owned assistant history store.
+- Kept every Codex run scoped to the active workspace root while still sending the current note title, note body, workspace path, workspace name, and note path as the primary prompt context.
+- Removed Mohio-specific note-thread migration logic because Codex now owns session identity and history.
+- Added main-process and renderer coverage for Codex thread listing, streamed updates, app-server startup, and assistant UI behavior.
 - Updated feature, architecture, design, and manual documentation to reflect the live assistant workflow.
 
 ## Decision
 
-Shipped the first assistant integration as chat-only, read-only workspace assistance through `codex exec` instead of jumping directly to structured document edits or a deeper persistent Codex protocol. This keeps the product behavior explicit and reviewable while still making the assistant useful inside the existing workspace flow.
+Shipped the first assistant integration as chat-only, read-only workspace assistance on top of Codex's native session ecosystem instead of inventing a Mohio-owned history layer. This keeps Mohio aligned with the user's existing Codex setup while still making the assistant useful inside the existing workspace flow.
 
 ## Impact
 
-Mohio now includes a real embedded Codex assistant in the desktop shell. Users can ask for note and workspace help from the right sidebar without leaving the app, while the product still avoids silent assistant-driven file mutations.
+Mohio now includes a real embedded Codex assistant in the desktop shell. Users can browse existing Codex chats for the current workspace, run multiple chats in parallel, and keep using note-first prompts without leaving the app, while the product still avoids silent assistant-driven file mutations.

--- a/docs/changelog/feature-20260322-ai-assistance.md
+++ b/docs/changelog/feature-20260322-ai-assistance.md
@@ -1,0 +1,28 @@
+# Add Codex AI Assistance Panel
+
+## Date
+
+2026-03-22
+
+## Context
+
+Mohio already had a three-panel desktop shell, but the right sidebar was only visual scaffolding. The roadmap called for embedded AI assistance inside the workspace, and the desktop app needed a real first assistant workflow that matched the existing bring-your-own-AI direction without letting the assistant silently change workspace files.
+
+## Change
+
+- Added a live assistant runtime in the Electron main process that starts the installed `codex` CLI with JSON event streaming.
+- Added assistant IPC methods and shared types for loading note threads, sending note-scoped messages, cancelling active runs, and receiving streamed assistant updates.
+- Implemented the right sidebar as a working Codex chat panel with transcript bubbles, quick actions, composer input, cancel behavior, and panel-local error handling.
+- Scoped conversations per note for the current app session while still running each Codex call from the active workspace root.
+- Passed the current note title, note body, workspace path, workspace name, and note-thread history into each assistant prompt.
+- Migrated in-memory assistant thread state when note saves rename a file through the title edit flow.
+- Added main-process and renderer coverage for Codex command startup, streamed updates, cancellation, rename migration, and assistant UI behavior.
+- Updated feature, architecture, design, and manual documentation to reflect the live assistant workflow.
+
+## Decision
+
+Shipped the first assistant integration as chat-only, read-only workspace assistance through `codex exec` instead of jumping directly to structured document edits or a deeper persistent Codex protocol. This keeps the product behavior explicit and reviewable while still making the assistant useful inside the existing workspace flow.
+
+## Impact
+
+Mohio now includes a real embedded Codex assistant in the desktop shell. Users can ask for note and workspace help from the right sidebar without leaving the app, while the product still avoids silent assistant-driven file mutations.

--- a/docs/design.md
+++ b/docs/design.md
@@ -52,10 +52,12 @@ Mohio uses a desktop-first three-panel layout with a slim top bar.
 ### Right Sidebar
 
 - Width target: `384px`
-- Purpose: reserve space for assistant-driven workflows
+- Purpose: support assistant-driven note and workspace conversations
 - Rules:
-  - keep the panel quiet until real assistant actions exist
-  - show lightweight suggestion text instead of dense instructional UI
+  - keep the panel visually secondary to the editor
+  - use concise note and workspace context in the header
+  - show transcript bubbles instead of dense settings chrome
+  - use quick-action chips for common note workflows
   - composer stays anchored at the bottom
 
 ## Visual Tokens
@@ -132,13 +134,22 @@ Mohio uses a desktop-first three-panel layout with a slim top bar.
 - Use one clear message
 - Use one clear next action
 
+### Assistant Panel
+
+- Keep message bubbles compact and readable
+- Use the same surface palette as the rest of the shell
+- Keep assistant errors local to the panel footer
+- Disable quick actions and the composer while a run is active
+
 ## Interaction Rules
 
 - Opening a workspace should update the shell immediately.
 - Selecting a document should feel instant and should not expose raw IPC or filesystem concepts.
 - Saving should be automatic and mostly invisible.
 - Error messages should be brief and local to the affected panel.
-- Assistant UI should remain secondary to the document until real workflows are implemented.
+- Assistant UI should remain secondary to the document even when live.
+- Switching notes should switch the visible assistant thread with the note.
+- Assistant runs should stream text into the panel instead of waiting for a full-page transition.
 
 ## Responsive Guidance
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -55,8 +55,11 @@ Mohio uses a desktop-first three-panel layout with a slim top bar.
 - Purpose: support assistant-driven note and workspace conversations
 - Rules:
   - keep the panel visually secondary to the editor
-  - use concise note and workspace context in the header
-  - show transcript bubbles instead of dense settings chrome
+  - start with a dedicated session-list screen instead of mixing history and transcript together
+  - keep the list-view header minimal and use one clear `New Chat` action
+  - use a detail header with back navigation, thread title, and a compact overflow menu
+  - keep header icon controls lightweight, without bordered icon chrome for back, new-chat, or chat-menu actions
+  - avoid bubble chrome for assistant answers; render them as full-width left-aligned note-style responses
   - use quick-action chips for common note workflows
   - composer stays anchored at the bottom
 
@@ -106,6 +109,9 @@ Mohio uses a desktop-first three-panel layout with a slim top bar.
 
 ## Component Rules
 
+- Use Title Case for visible button labels.
+- Exception: assistant quick-action chips use sentence case.
+
 ### Workspace Selector
 
 - Treated as the main entry point when no workspace is open
@@ -116,12 +122,14 @@ Mohio uses a desktop-first three-panel layout with a slim top bar.
 - Prefer compact rows over roomy file-explorer spacing
 - Show display titles when available instead of raw filenames
 - Keep nesting readable with indentation, not heavy borders
+- Show a lightweight `New Note` icon control in the workspace header, using the same unframed icon-button treatment as the assistant panel
 
 ### Editor Toolbar
 
 - Only include actions that work today
 - Group controls by formatting type
 - Prefer compact icon buttons and short heading buttons over large segmented chrome
+- Use `lucide-react` consistently for shared shell and editor icons
 
 ### Title Input
 
@@ -136,7 +144,15 @@ Mohio uses a desktop-first three-panel layout with a slim top bar.
 
 ### Assistant Panel
 
-- Keep message bubbles compact and readable
+- show Codex chats as a simple first-stage text list of selectable titles
+- use a single clear `New Chat` action in the list view instead of mode-heavy controls
+- use `message-square-plus` for the list-view `New Chat` action
+- when a thread is open, show back navigation and thread-level actions instead of the history list
+- keep the assistant footer pinned to the bottom of the right sidebar in both list and thread views
+- Keep user prompts compact, but render assistant answers as full-width left-aligned responses
+- Keep `Thinking...` as a separate last-line status row, not as replacement text inside the assistant response
+- Hide `Thinking...` while assistant text is actively streaming, and bring it back only during quiet gaps in an active run
+- Never let streamed assistant text disappear once it has been rendered
 - Use the same surface palette as the rest of the shell
 - Keep assistant errors local to the panel footer
 - Disable quick actions and the composer while a run is active
@@ -148,7 +164,8 @@ Mohio uses a desktop-first three-panel layout with a slim top bar.
 - Saving should be automatic and mostly invisible.
 - Error messages should be brief and local to the affected panel.
 - Assistant UI should remain secondary to the document even when live.
-- Switching notes should switch the visible assistant thread with the note.
+- Switching chats should not change the selected note.
+- Switching notes should keep the active Codex chat, but future prompts should use the newly selected note as primary context.
 - Assistant runs should stream text into the panel instead of waiting for a full-page transition.
 
 ## Responsive Guidance

--- a/docs/features/ai-assistance-panel.md
+++ b/docs/features/ai-assistance-panel.md
@@ -5,31 +5,34 @@ This document covers the current Codex integration in the right sidebar of `desk
 ## Scope
 
 - assistant IPC surface
-- main-process Codex execution
-- renderer transcript and composer UI
-- note-scoped in-session conversation state
+- main-process Codex app-server client
+- renderer chat history, transcript, and composer UI
+- note-aware prompting on top of Codex-owned threads
 
 ## Current State
 
 - The right sidebar is a live assistant panel instead of layout scaffolding.
-- Mohio uses the installed `codex` CLI through `codex exec`.
-- Each assistant run executes from the active workspace root.
+- Mohio uses the installed `codex` CLI through `codex app-server`.
+- Each chat runs from the active workspace root.
 - Codex is limited to read-only workspace access in this integration.
-- Assistant conversations are kept separately per note for the current app session only.
-- Mohio does not persist assistant history across restarts.
+- Mohio reuses Codex's existing auth, config, and on-disk session history.
+- Mohio does not keep a separate chat-history database or note-thread store.
 - Mohio does not let the assistant apply edits, patches, or note proposals yet.
 
 ## API Surface
 
 The renderer uses `window.mohio` for assistant behavior:
 
-- `getAssistantThread(noteRelativePath)`
+- `listAssistantThreads()`
+- `createAssistantThread()`
+- `getAssistantThread(threadId)`
 - `sendAssistantMessage(input)`
-- `cancelAssistantRun(noteRelativePath)`
+- `cancelAssistantRun(threadId)`
 - `onAssistantEvent(listener)`
 
 Assistant input payload:
 
+- `threadId`
 - `noteRelativePath`
 - `content`
 - `documentTitle`
@@ -37,45 +40,65 @@ Assistant input payload:
 
 Assistant thread shape:
 
-- note-relative thread identity
+- Codex thread identity
+- workspace path
+- title and preview for history rows
 - ordered `user` and `assistant` messages
 - run status: `idle`, `running`, or `error`
 - optional panel-local error message
 
 ## Runtime Behavior
 
-- The main process spawns `codex` with JSON event output enabled.
-- Mohio runs Codex from the active workspace root with:
-  - `exec`
-  - `--json`
-  - `--ephemeral`
-  - `--skip-git-repo-check`
-  - `--sandbox read-only`
-- Mohio passes the current note title, note body, note path, workspace name, workspace path, and note-thread history in the prompt.
+- The main process starts a long-lived `codex app-server` child process and talks to it over JSON-RPC.
+- Mohio creates and resumes Codex threads with:
+  - `cwd` set to the active workspace root
+  - `approvalPolicy: never`
+  - `sandbox: read-only`
+  - Mohio-specific developer instructions
+  - persistent Codex thread history enabled
+- Mohio lists Codex threads with the current workspace path as the `cwd` filter.
+- Mohio loads full transcript history from Codex through `thread/read`.
+- Mohio passes the current note title, note body, note path, workspace name, workspace path, and the user's request into each turn prompt.
 - Codex may inspect any file in the active workspace during the run.
-- Mohio streams assistant text into the sidebar as JSONL events arrive.
-- Non-fatal stderr output is treated as diagnostics.
+- Mohio streams assistant text into the sidebar from Codex app-server notifications.
 - Failed runs stay local to the assistant panel and do not affect editor state.
 
 ## Renderer Behavior
 
-- The header shows the assistant label plus the current note and workspace context.
-- The transcript renders chat bubbles for the current note thread only.
+- The sidebar starts in a session-list view for the current workspace.
+- The list view shows a minimal `Assistant` header, a `New Chat` action, and a simple workspace-filtered title list of Codex chats.
+- The list-view `New Chat` action uses a `message-square-plus` icon.
+- Opening a chat switches the sidebar into a dedicated thread view.
+- A newly created chat stays in the dedicated thread view even before Codex includes it in the workspace history list.
+- The thread view header includes:
+  - a back action to return to the session list
+  - the current Codex thread title
+  - a menu with `New Chat`, `Rename Chat`, and `Delete Chat`
+- The list-view `New Chat` control, the thread-view back control, and the `...` menu trigger use simple unframed icon buttons.
+- Assistant panel icons use `lucide-react`, matching the rest of the desktop shell.
+- Mohio does not show a separate empty helper paragraph inside a brand new chat before the first message.
+- Users can switch between existing Codex chats without changing the selected note.
+- The transcript renders only in the active thread view.
+- The assistant footer stays pinned at the bottom of the right sidebar in both list and thread views, below the chat list when browsing sessions.
+- User prompts remain compact, while assistant answers render as full-width left-aligned responses instead of chat bubbles.
+- Mohio keeps streamed assistant text visible once it appears and never replaces it with a placeholder.
+- While a Codex run is active and no new assistant text has arrived yet, Mohio shows a muted animated `Thinking...` line as the last row in the transcript.
+- Mohio hides that `Thinking...` line while fresh assistant text is actively streaming, and shows it again only if the run is still active but the stream goes quiet.
 - Quick actions send:
   - `Summarize this note`
   - `Organize this note`
   - `Suggest related notes from this workspace`
-- The composer is disabled when no workspace is open, no note is selected, or a run is already active.
-- The cancel button stops the current note-thread run.
-
-## Rename Handling
-
-- If a note rename changes the relative path during save, main migrates the existing assistant thread to the new note path.
-- This preserves the in-session conversation when the file name changes from the title edit flow.
+- The composer is disabled when no workspace is open, no note is selected, or the active Codex thread is already running.
+- Sending from the list view footer always starts a fresh chat automatically before dispatching the prompt.
+- If no Codex thread is active in thread view, sending a message starts a new one first.
+- If the user opens an existing Codex chat from history, Mohio resumes that thread with Codex before starting the next turn.
+- If Codex rejects turn startup on a freshly created thread because no rollout exists yet, Mohio resumes the thread and retries turn startup with bounded backoff before surfacing an error.
+- The cancel button stops the active Codex thread.
+- `Delete Chat` maps to Codex thread archive behavior and removes the thread from Mohio's visible workspace list.
 
 ## Current Limitations
 
 - Only Codex is wired today; Claude Code is not yet integrated.
-- Assistant history is not stored on disk.
+- Mohio does not offer chat search, archive, or fork UI yet.
 - There is no review/apply workflow for assistant-generated document changes.
 - There is no assistant tool UI for note creation, publish, or history actions yet.

--- a/docs/features/ai-assistance-panel.md
+++ b/docs/features/ai-assistance-panel.md
@@ -1,0 +1,81 @@
+# AI Assistance Panel
+
+This document covers the current Codex integration in the right sidebar of `desktop/`.
+
+## Scope
+
+- assistant IPC surface
+- main-process Codex execution
+- renderer transcript and composer UI
+- note-scoped in-session conversation state
+
+## Current State
+
+- The right sidebar is a live assistant panel instead of layout scaffolding.
+- Mohio uses the installed `codex` CLI through `codex exec`.
+- Each assistant run executes from the active workspace root.
+- Codex is limited to read-only workspace access in this integration.
+- Assistant conversations are kept separately per note for the current app session only.
+- Mohio does not persist assistant history across restarts.
+- Mohio does not let the assistant apply edits, patches, or note proposals yet.
+
+## API Surface
+
+The renderer uses `window.mohio` for assistant behavior:
+
+- `getAssistantThread(noteRelativePath)`
+- `sendAssistantMessage(input)`
+- `cancelAssistantRun(noteRelativePath)`
+- `onAssistantEvent(listener)`
+
+Assistant input payload:
+
+- `noteRelativePath`
+- `content`
+- `documentTitle`
+- `documentMarkdown`
+
+Assistant thread shape:
+
+- note-relative thread identity
+- ordered `user` and `assistant` messages
+- run status: `idle`, `running`, or `error`
+- optional panel-local error message
+
+## Runtime Behavior
+
+- The main process spawns `codex` with JSON event output enabled.
+- Mohio runs Codex from the active workspace root with:
+  - `exec`
+  - `--json`
+  - `--ephemeral`
+  - `--skip-git-repo-check`
+  - `--sandbox read-only`
+- Mohio passes the current note title, note body, note path, workspace name, workspace path, and note-thread history in the prompt.
+- Codex may inspect any file in the active workspace during the run.
+- Mohio streams assistant text into the sidebar as JSONL events arrive.
+- Non-fatal stderr output is treated as diagnostics.
+- Failed runs stay local to the assistant panel and do not affect editor state.
+
+## Renderer Behavior
+
+- The header shows the assistant label plus the current note and workspace context.
+- The transcript renders chat bubbles for the current note thread only.
+- Quick actions send:
+  - `Summarize this note`
+  - `Organize this note`
+  - `Suggest related notes from this workspace`
+- The composer is disabled when no workspace is open, no note is selected, or a run is already active.
+- The cancel button stops the current note-thread run.
+
+## Rename Handling
+
+- If a note rename changes the relative path during save, main migrates the existing assistant thread to the new note path.
+- This preserves the in-session conversation when the file name changes from the title edit flow.
+
+## Current Limitations
+
+- Only Codex is wired today; Claude Code is not yet integrated.
+- Assistant history is not stored on disk.
+- There is no review/apply workflow for assistant-generated document changes.
+- There is no assistant tool UI for note creation, publish, or history actions yet.

--- a/docs/features/desktop-shell-and-workspace.md
+++ b/docs/features/desktop-shell-and-workspace.md
@@ -20,7 +20,7 @@ This document covers the current shell and workspace flow in `desktop/`.
   - center editor panel
   - right assistant sidebar
 - The renderer is implemented in `React` and `TypeScript`.
-- The right sidebar is layout scaffolding only.
+- The right sidebar hosts the live Codex assistant panel.
 
 ## Menu and Native Entry Points
 
@@ -40,8 +40,12 @@ Current API surface:
 - `readDocument(relativePath)`
 - `saveDocument(input)`
 - `watchDocument(relativePath | null)`
+- `getAssistantThread(noteRelativePath)`
+- `sendAssistantMessage(input)`
+- `cancelAssistantRun(noteRelativePath)`
 - `onWorkspaceChanged(listener)`
 - `onDocumentChanged(listener)`
+- `onAssistantEvent(listener)`
 
 ## Workspace Enumeration
 
@@ -84,6 +88,7 @@ Current API surface:
 
 - The selected document loads into the editor panel.
 - The active row is highlighted in the workspace tree.
+- The assistant sidebar shows a note-scoped Codex conversation for the selected note.
 
 ## Security Boundary
 
@@ -98,6 +103,7 @@ Current API surface:
 - No delete-note UI
 - No search implementation behind the search field
 - No recent-note or pinned-note behavior yet
+- Assistant history is not persisted across restarts
 
 ## Code Anchors
 

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -4,6 +4,8 @@ This section is developer-facing. It documents Mohio's current implementation an
 
 ## Current Modules
 
+- [AI Assistance Panel](ai-assistance-panel.md)
+  - Codex-backed workspace chat, per-note in-session threads, and assistant IPC
 - [Desktop Shell and Workspace](desktop-shell-and-workspace.md)
   - Electron shell, preload bridge, workspace selection, and workspace tree behavior
 - [Document Editing and Persistence](document-editing-and-persistence.md)

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -5,7 +5,7 @@ This section is developer-facing. It documents Mohio's current implementation an
 ## Current Modules
 
 - [AI Assistance Panel](ai-assistance-panel.md)
-  - Codex-backed workspace chat, per-note in-session threads, and assistant IPC
+  - Codex-backed workspace chat, Codex-native history, parallel chats, and assistant IPC
 - [Desktop Shell and Workspace](desktop-shell-and-workspace.md)
   - Electron shell, preload bridge, workspace selection, and workspace tree behavior
 - [Document Editing and Persistence](document-editing-and-persistence.md)

--- a/docs/manual/desktop-basics.md
+++ b/docs/manual/desktop-basics.md
@@ -18,6 +18,9 @@ You can open a workspace in either of these ways:
 
 After you choose a folder, Mohio shows its Markdown documents in the left sidebar.
 
+When no workspace is open, the main empty-state button is labeled `Open Workspace`.
+The workspace sidebar also shows a `New Note` icon button, but note creation from the UI is still not available yet.
+
 ## Browse Documents
 
 - Folders appear before documents.
@@ -46,13 +49,21 @@ After you choose a folder, Mohio shows its Markdown documents in the left sideba
 ## Use the Assistant Panel
 
 - Open a workspace and select a note.
-- Use the right sidebar to chat with Codex about the current note.
+- Use the right sidebar to browse Codex chats for the current workspace.
+- The assistant opens in a chat-list view first.
+- Click an existing chat to open it, or click `New Chat` to start another parallel conversation.
+- The quick actions and composer stay at the bottom of the sidebar while you browse the chat list.
+- If you trigger a quick action or send a message from the list view, Mohio automatically starts a new chat first.
+- When a chat is open, use the back button to return to the list.
+- Use the `...` menu in an open chat to start another chat, rename the current one, or remove it from the visible workspace list.
+- Your own prompts appear as compact bubbles, but Codex replies render as full-width left-aligned responses.
+- While Codex is still working, Mohio keeps a muted animated `Thinking...` line at the bottom of the chat during quiet gaps, hides it while fresh text is printing, and leaves streamed text visible once it appears.
 - You can type your own request or use the quick actions:
   - summarize the note
   - organize the note
   - suggest related notes from the current workspace
 - Mohio sends the current note content along with the wider workspace context for that run.
-- The conversation stays attached to the selected note while the app is open.
+- The selected note stays the main context for what you send, but the chat history itself comes from Codex and is not tied to one note inside Mohio.
 - Use `Cancel` if you want to stop the current assistant response.
 
 ## Current Limits
@@ -60,6 +71,6 @@ After you choose a folder, Mohio shows its Markdown documents in the left sideba
 - You cannot create a new note from the UI yet.
 - You cannot rename or delete notes from a dedicated sidebar action yet.
 - Search is not active yet.
-- Assistant history is not saved across app restarts yet.
+- Mohio only shows Codex chats whose working folder matches the open workspace.
 - The assistant can chat about your workspace, but it cannot apply note edits through Mohio yet.
 - There is no rendered preview or split view for Markdown yet.

--- a/docs/manual/desktop-basics.md
+++ b/docs/manual/desktop-basics.md
@@ -43,10 +43,23 @@ After you choose a folder, Mohio shows its Markdown documents in the left sideba
 - Mohio watches the document that is currently open.
 - If that file changes on disk, Mohio reloads it when it can do so safely.
 
+## Use the Assistant Panel
+
+- Open a workspace and select a note.
+- Use the right sidebar to chat with Codex about the current note.
+- You can type your own request or use the quick actions:
+  - summarize the note
+  - organize the note
+  - suggest related notes from the current workspace
+- Mohio sends the current note content along with the wider workspace context for that run.
+- The conversation stays attached to the selected note while the app is open.
+- Use `Cancel` if you want to stop the current assistant response.
+
 ## Current Limits
 
 - You cannot create a new note from the UI yet.
 - You cannot rename or delete notes from a dedicated sidebar action yet.
 - Search is not active yet.
-- The assistant panel is present, but it is not connected to a live workflow yet.
+- Assistant history is not saved across app restarts yet.
+- The assistant can chat about your workspace, but it cannot apply note edits through Mohio yet.
 - There is no rendered preview or split view for Markdown yet.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -53,7 +53,23 @@ Planned focus areas:
 - Show what the assistant changed instead of hiding modifications.
 - Aim for natural product-language interactions even when the connected assistant is Codex or Claude Code.
 
-### 5. Note and Document Management
+### 4. Notes and Documents
+
+- Seperate notes and documents
+- Notes are used to capture quick thoughts, ideas.
+- Documents are used to capture structured knowledge that is shared with the team.
+- Notes are private to the user and are not shared with the team.
+- Documents are shared with the team and are visible to all members of the workspace.
+- Notes are order by last modified time and are not organized in a hierarchy.
+- Documents are organized in a hierarchy and are shared with the team.
+- Notes can be promoted to documents when they are ready to be shared with the team.
+- The left panel has 2 tabs: Notes and Documents. The Notes tab shows the user's private notes in a list with a timestamp prefix.
+- The notes can be order by modified time or created time. The user can switch between the two sorting options. (A-Z or Z-A)
+- The documents tab shows the shared documents in a folder hierarchical structure.
+- The documents can be ordered by name or modified time. The user can switch between the two sorting options. (A-Z or Z-A)
+- Notes are created with a timestamp prefix in the title to make it easy to find them later in the _notes folder. The format of the timestamp is `yyyymmdd-hhmmss` + the standard document title algorithm (e.g. `20231001-143000 My Note`).
+
+### 4. Note and Document Management
 
 - Create a new note from inside the app.
 - Open a newly created note immediately.


### PR DESCRIPTION
## Summary
- ship the Codex app-server assistant integration in the desktop shell with workspace-scoped chat history and note-aware prompts
- finalize the two-stage assistant UX (chat list + thread view), footer behavior, quick actions, streaming transcript handling, and thread management actions
- harden fresh-thread startup and streaming edge cases (`no rollout found`, unmaterialized reads, and stream-completion text persistence)

## Verification
- `cd desktop && npm test`
- `cd desktop && npm run typecheck`
- `cd desktop && npm run build`

## Documentation Updated
- `docs/features/ai-assistance-panel.md`
- `docs/manual/desktop-basics.md`
- `docs/design.md`
- `docs/architecture.md`
- `docs/changelog/feature-20260322-ai-assistance.md`
- `docs/features/index.md`
- `docs/roadmap.md`
- `README.md`

## Notes
- assistant remains chat-only and read-only for workspace files in this version
- no Mohio-owned chat history store was introduced; this reuses Codex sessions/config/auth
